### PR TITLE
Add screenshot command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## Unreleased
 ### Fixed
 - Fix downloading projects with subdirectories
+### Added
+- Command to capture a screenshot from the remote device
 
 ## 0.2.0 - 2017-08-15
 ### Added

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
             },
             {
                 "command": "ev3devBrowser.captureScreenshot",
-                "title": "Take Screenshot",
-                "category": "ev3dev"
+                "title": "Take Screenshot"
             },
             {
                 "command": "ev3devBrowser.remoteRun",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
                 "category": "ev3dev"
             },
             {
+                "command": "ev3devBrowser.captureScreenshot",
+                "title": "Take Screenshot",
+                "category": "ev3dev"
+            },
+            {
                 "command": "ev3devBrowser.remoteRun",
                 "title": "Run",
                 "category": "ev3dev"
@@ -137,6 +142,10 @@
                     "when": "view == ev3devBrowser && viewItem == ev3devDevice"
                 },
                 {
+                    "command": "ev3devBrowser.captureScreenshot",
+                    "when": "view == ev3devBrowser && viewItem == ev3devDevice"
+                },
+                {
                     "command": "ev3devBrowser.remoteRun",
                     "when": "view == ev3devBrowser && viewItem == executableFile"
                 },
@@ -172,6 +181,7 @@
         "@types/node": "^6.0.85",
         "@types/ssh2": "~0.5.35",
         "@types/ssh2-streams": "~0.1.2",
+        "@types/temp": "^0.8.3",
         "mocha": "^2.3.3",
         "typescript": "^2.4.2",
         "vscode": "^1.0.0"
@@ -182,6 +192,7 @@
         "dbus-native": "^0.2.2",
         "dnode": "^1.2.2",
         "ssh2": "~0.5.5",
-        "ssh2-streams": "~0.1.19"
+        "ssh2-streams": "~0.1.19",
+        "temp": "^0.8.3"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,16 @@
-import * as dnode from 'dnode';
+import * as dnode from 'dnode'
+import * as fs from 'fs'
 import * as net from 'net'
+
 import * as path from 'path'
 import * as ssh2 from 'ssh2'
 import * as ssh2Streams from 'ssh2-streams'
-import * as vscode from 'vscode';
+import * as temp from 'temp'
+
+import * as vscode from 'vscode'
 
 import * as dnssd from './dnssd'
+import { sanitizedDateString, getSharedTempDir, verifyFileHeader } from './utils'
 
 const S_IXUSR = parseInt('00100', 8);
 
@@ -31,6 +36,7 @@ export async function activate(context: vscode.ExtensionContext) : Promise<void>
     ev3devBrowserProvider = new Ev3devBrowserProvider();
     context.subscriptions.push(vscode.window.registerTreeDataProvider('ev3devBrowser', ev3devBrowserProvider));
     context.subscriptions.push(vscode.commands.registerCommand('ev3devBrowser.openSshTerminal', d => ev3devBrowserProvider.openSshTerminal(d)));
+    context.subscriptions.push(vscode.commands.registerCommand('ev3devBrowser.captureScreenshot', d => ev3devBrowserProvider.captureScreenshot(d)));
     context.subscriptions.push(vscode.commands.registerCommand('ev3devBrowser.deviceClicked', d => d.handleClick()));
     context.subscriptions.push(vscode.commands.registerCommand('ev3devBrowser.fileClicked', f => f.handleClick()));
     context.subscriptions.push(vscode.commands.registerCommand('ev3devBrowser.remoteRun', f => f.run()));
@@ -47,6 +53,9 @@ export function deactivate() {
         device.destroy();
     }
     dnssdClient.destroy();
+
+    // The "temp" module should clean up automatically, but do this just in case.
+    temp.cleanupSync();
 }
 
 /**
@@ -197,6 +206,10 @@ class Ev3devBrowserProvider implements vscode.TreeDataProvider<Device | File> {
 
     openSshTerminal(device: Device): void {
         device.openSshTerminal();
+    }
+    
+    captureScreenshot(device: Device): void {
+        device.captureScreenshot();
     }
 
 	getTreeItem(element: Device | File): vscode.TreeItem {
@@ -521,6 +534,58 @@ class Device extends vscode.TreeItem {
             [this.shellPort.toString()]);
         term.show();
     }
+    
+    async captureScreenshot() {
+        const statusBarMessage = vscode.window.createStatusBarItem();
+        statusBarMessage.text = "Attempting to capture screenshot...";
+        statusBarMessage.show();
+
+        const handleCaptureError = (e) => {
+            vscode.window.showErrorMessage("Error capturing screenshot: " + (e.message || e));
+            statusBarMessage.dispose();
+        }
+
+        try {
+            const screenshotDirectory = await getSharedTempDir('ev3dev-screenshots');
+            const screenshotBaseName = `ev3dev-${sanitizedDateString()}.png`;
+            const screenshotFile = `${screenshotDirectory}/${screenshotBaseName}`;
+
+            const conn = await this.exec('fbgrab -');
+            const writeStream = fs.createWriteStream(screenshotFile);
+
+            conn.on('error', (e: Error) => {
+                writeStream.removeAllListeners('finish');
+                handleCaptureError(e);
+            });
+
+            writeStream.on('open', () => {
+                conn.stdout.pipe(writeStream);
+            });
+            
+            writeStream.on('error', (e: Error) => {
+                vscode.window.showErrorMessage("Error saving screenshot: " + e.message);
+                statusBarMessage.dispose();
+            });
+
+            writeStream.on('finish', async () => {
+                const pngHeader = [ 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A ];
+                if(await verifyFileHeader(screenshotFile, pngHeader)) {
+                    statusBarMessage.text = `Screenshot "${screenshotBaseName}" successfully captured`;
+                    vscode.commands.executeCommand('vscode.open', vscode.Uri.file(screenshotFile));
+    
+                    // Remove message after giving time to read it
+                    setTimeout(() => statusBarMessage.dispose(), 5000);
+                }
+                else {
+                    handleCaptureError("The captured screenshot was not in the expected format."
+                        + " This may be caused by running an old version of 'fbcat' on the remote device; try updating the fbcat package.");
+                }
+            });
+        }
+        catch (e) {
+            handleCaptureError(e);
+        }
+    }
 
 	iconPath = {
 		dark: path.join(resourceDir, 'icons', 'dark', 'yellow-circle.svg'),
@@ -626,7 +691,7 @@ class File extends vscode.TreeItem {
         }
     }
 
-    run() :void {
+    run(): void {
         const command = `conrun -e ${this.path}`;
         output.show(true);
         output.clear();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
-import * as temp from 'temp'
-import * as fs from 'fs'
-import { isArray } from 'util'
+import * as vscode from 'vscode';
+import * as temp from 'temp';
+import * as fs from 'fs';
+import { isArray } from 'util';
 
 export function sanitizedDateString(date?: Date) {
     const d = date || new Date();
@@ -54,4 +55,57 @@ export async function verifyFileHeader(filePath: string, expectedHeader: Buffer 
     const bufferExpectedHeader = isArray(expectedHeader) ? new Buffer(<number[]>expectedHeader) : <Buffer>expectedHeader;
     const header = await openAndRead(filePath, 0, bufferExpectedHeader.length, offset);
     return header.compare(bufferExpectedHeader) == 0;
+}
+
+export class StatusBarProgressionMessage {
+    private statusBarItem: vscode.StatusBarItem;
+
+    constructor(initialMessage?: string) {
+        this.statusBarItem = vscode.window.createStatusBarItem();
+        if (initialMessage) {
+            this.statusBarItem.text = initialMessage;
+            this.statusBarItem.show();
+        }
+    }
+
+    /**
+     * Updates the displayed message.
+     * @param newMessage The new message to display
+     */
+    public update(newMessage: string) {
+        if (!this.statusBarItem) {
+            return;
+        }
+
+        this.statusBarItem.text = newMessage;
+        this.statusBarItem.show();
+    }
+
+    /**
+     * Marks the progression as being finished. If a message is specified, it is
+     * shown temporarily before the item disappears.
+     * 
+     * Note that a message should always be provided if an external message
+     * indicating a failure won't be presented to the user.
+     * @param finalMessage The last message to show for a short period
+     * @param delay The amount of time the final message should be shown
+     */
+    public finish(finalMessage?: string, delay: number = 5000) {
+        if (!this.statusBarItem) {
+            return;
+        }
+
+        if (finalMessage) {
+            this.update(finalMessage);
+            setTimeout(() => this.dispose(), delay);
+        }
+        else {
+            this.dispose();
+        }
+    }
+
+    private dispose() {
+        this.statusBarItem.dispose();
+        this.statusBarItem = null;
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,57 @@
+import * as temp from 'temp'
+import * as fs from 'fs'
+import { isArray } from 'util'
+
+export function sanitizedDateString(date?: Date) {
+    const d = date || new Date();
+    const pad = (num: number) => ("00" + num).slice(-2);
+
+    return `${d.getFullYear()}-${pad(d.getMonth())}-${pad(d.getDay())}-${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}`;
+}
+
+const tempDirs: { [sharedKey: string]: string } = {};
+export function getSharedTempDir(sharedKey: string): Promise<string> {
+    if (tempDirs[sharedKey]) {
+        return Promise.resolve(tempDirs[sharedKey]);
+    }
+
+    return new Promise((resolve, reject) => {
+        temp.track();
+        temp.mkdir(sharedKey, (err, dirPath) => {
+            if (err) {
+                reject(err);
+            }
+            else {
+                tempDirs[sharedKey] = dirPath;
+                resolve(dirPath);
+            }
+        })
+    });
+}
+
+export function openAndRead(path: string, offset: number, length: number, position: number): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        fs.open(path, 'r', (err, fd) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            const buffer = new Buffer(length);
+            fs.read(fd, buffer, offset, length, position, (err, bytesRead, buffer) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                resolve(buffer);
+            });
+        });
+    })
+}
+
+export async function verifyFileHeader(filePath: string, expectedHeader: Buffer | number[], offset?: number): Promise<boolean> {
+    const bufferExpectedHeader = isArray(expectedHeader) ? new Buffer(<number[]>expectedHeader) : <Buffer>expectedHeader;
+    const header = await openAndRead(filePath, 0, bufferExpectedHeader.length, offset);
+    return header.compare(bufferExpectedHeader) == 0;
+}


### PR DESCRIPTION
This implementation drops screenshots in a folder called `ev3dev-screenshots` and opens the newly-captured image in the viewer. We should discuss if we instead want to adopt a different behavior, e.g. saving it to a temporary file. The reason I chose this approach is that you can't easily retrieve the file with just an open preview window.

Also, the current implementation will get really unhappy if you don't have any workspace open. We need to figure out what to do there.

Fixes #4 
