### PR TITLE
Add sysinfo command

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
                 "title": "Take Screenshot"
             },
             {
+                "command": "ev3devBrowser.deviceTreeItem.printSysinfo",
+                "title": "Get ev3dev system info"
+            },
+            {
                 "command": "ev3devBrowser.deviceTreeItem.connect",
                 "title": "Connect"
             },
@@ -195,6 +199,11 @@
                 },
                 {
                     "command": "ev3devBrowser.deviceTreeItem.captureScreenshot",
+                    "when": "view == ev3devBrowser && viewItem == ev3devBrowser.device.connected",
+                    "group": "primary@2"
+                },
+                {
+                    "command": "ev3devBrowser.deviceTreeItem.printSysinfo",
                     "when": "view == ev3devBrowser && viewItem == ev3devBrowser.device.connected",
                     "group": "primary@2"
                 },

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
                 "title": "Take Screenshot"
             },
             {
-                "command": "ev3devBrowser.deviceTreeItem.printSysinfo",
-                "title": "Get ev3dev system info"
+                "command": "ev3devBrowser.deviceTreeItem.showSysinfo",
+                "title": "Get system info"
             },
             {
                 "command": "ev3devBrowser.deviceTreeItem.connect",
@@ -203,9 +203,9 @@
                     "group": "primary@2"
                 },
                 {
-                    "command": "ev3devBrowser.deviceTreeItem.printSysinfo",
+                    "command": "ev3devBrowser.deviceTreeItem.showSysinfo",
                     "when": "view == ev3devBrowser && viewItem == ev3devBrowser.device.connected",
-                    "group": "primary@2"
+                    "group": "primary@3"
                 },
                 {
                     "command": "ev3devBrowser.fileTreeItem.run",

--- a/src/device.ts
+++ b/src/device.ts
@@ -397,21 +397,16 @@ export class Device extends vscode.Disposable {
     }
 
     public getSystemInfo(): Promise<string> {
-        return new Promise((resolve, reject) => {
-            this.exec('ev3dev-sysinfo').then(conn => {
-                let sysinfoString = '';
-                conn.stdout.on('data', buffer => sysinfoString += buffer.toString());
-                conn.stdout.on('error', (err) => {
-                    conn.close();
-                    conn.stdout.removeAllListeners('end');
-                    reject(err);
-                });
+        return new Promise(async (resolve, reject) => {
+            const conn = await this.exec('ev3dev-sysinfo');
+            let sysinfoString = '';
+            conn.stdout.on('data', buffer => sysinfoString += buffer.toString());
+            conn.stdout.once('error', (err) => {
+                conn.close();
+                reject(err);
+            });
 
-                conn.stdout.on('end', () => {
-                    conn.close();
-                    resolve(sysinfoString);
-                });
-            }, reject);
+            conn.stdout.once('end', () => resolve(sysinfoString));
         });
     }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -332,7 +332,7 @@ export class Device extends vscode.Disposable {
      * @param local The path to a local file.
      * @param remote The remote path where the file will be saved.
      */
-    put(local: string, remote: string): Promise<void> {
+    public put(local: string, remote: string): Promise<void> {
         return new Promise((resolve, reject) => {
             this.sftp.fastPut(local, remote, (err) => {
                 if (err) {
@@ -393,6 +393,25 @@ export class Device extends vscode.Disposable {
                     resolve();
                 }
             })
+        });
+    }
+
+    public getSystemInfo(): Promise<string> {
+        return new Promise((resolve, reject) => {
+            this.exec('ev3dev-sysinfo').then(conn => {
+                let sysinfoString = '';
+                conn.stdout.on('data', buffer => sysinfoString += buffer.toString());
+                conn.stdout.on('error', (err) => {
+                    conn.close();
+                    conn.stdout.removeAllListeners('end');
+                    reject(err);
+                });
+
+                conn.stdout.on('end', () => {
+                    conn.close();
+                    resolve(sysinfoString);
+                });
+            }, reject);
         });
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,6 +44,7 @@ export function activate(context: vscode.ExtensionContext) : void {
         vscode.window.registerTreeDataProvider('ev3devBrowser', ev3devBrowserProvider),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.openSshTerminal', d => d.openSshTerminal()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.captureScreenshot', d => d.captureScreenshot()),
+        vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.printSysinfo', d => d.printSysinfo()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.connect', d => d.connect()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.disconnect', d => d.disconnect()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.select', d => d.handleClick()),
@@ -407,6 +408,24 @@ class DeviceTreeItem extends vscode.TreeItem {
         }
         catch (e) {
             handleCaptureError(e);
+        }
+    }
+
+    public async printSysinfo() {
+        const messageBarItem = new StatusBarProgressionMessage("Grabbing ev3dev system info...");
+        try {
+            const sysinfo = await this.device.getSystemInfo();
+
+            output.appendLine("========== ev3dev-sysinfo ==========");
+            output.appendLine(sysinfo);
+            output.appendLine("");
+            output.show();
+
+            messageBarItem.finish("System info downloaded; see output window.");
+        }
+        catch(err) {
+            vscode.window.showErrorMessage("An error occurred while capturing system info: " + (err.message || err));
+            messageBarItem.finish();
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -408,24 +408,22 @@ class DeviceTreeItem extends vscode.TreeItem {
     }
 
     public async showSysinfo() {
-        vscode.window.withProgress({
-            location: vscode.ProgressLocation.Window,
-            title: 'Grabbing ev3dev system info...'
-        }, async progress => {
-            try {
-                const sysinfo = await this.device.getSystemInfo();
+        try {
+            const sysinfo = await vscode.window.withProgress({
+                location: vscode.ProgressLocation.Window,
+                title: 'Grabbing ev3dev system info...'
+            }, progress => this.device.getSystemInfo());
     
-                output.clear();
-                output.appendLine('========== ev3dev-sysinfo ==========');
-                output.appendLine(sysinfo);
-                output.show();
-    
-                toastStatusBarMessage('System info retrieved.');
-            }
-            catch(err) {
-                vscode.window.showErrorMessage('An error occurred while getting system info: ' + (err.message || err));
-            }
-        });
+            output.clear();
+            output.appendLine('========== ev3dev-sysinfo ==========');
+            output.appendLine(sysinfo);
+            output.show();
+
+            toastStatusBarMessage('System info retrieved');
+        }
+        catch(err) {
+            vscode.window.showErrorMessage('An error occurred while getting system info: ' + (err.message || err));
+        }
     }
 
     iconPath = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ export function activate(context: vscode.ExtensionContext) : void {
         vscode.window.registerTreeDataProvider('ev3devBrowser', ev3devBrowserProvider),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.openSshTerminal', d => d.openSshTerminal()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.captureScreenshot', d => d.captureScreenshot()),
-        vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.printSysinfo', d => d.printSysinfo()),
+        vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.showSysinfo', d => d.showSysinfo()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.connect', d => d.connect()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.disconnect', d => d.disconnect()),
         vscode.commands.registerCommand('ev3devBrowser.deviceTreeItem.select', d => d.handleClick()),
@@ -407,22 +407,25 @@ class DeviceTreeItem extends vscode.TreeItem {
         });
     }
 
-    public async printSysinfo() {
-        const messageBarItem = new StatusBarProgressionMessage("Grabbing ev3dev system info...");
-        try {
-            const sysinfo = await this.device.getSystemInfo();
-
-            output.appendLine("========== ev3dev-sysinfo ==========");
-            output.appendLine(sysinfo);
-            output.appendLine("");
-            output.show();
-
-            messageBarItem.finish("System info downloaded; see output window.");
-        }
-        catch(err) {
-            vscode.window.showErrorMessage("An error occurred while capturing system info: " + (err.message || err));
-            messageBarItem.finish();
-        }
+    public async showSysinfo() {
+        vscode.window.withProgress({
+            location: vscode.ProgressLocation.Window,
+            title: 'Grabbing ev3dev system info...'
+        }, async progress => {
+            try {
+                const sysinfo = await this.device.getSystemInfo();
+    
+                output.clear();
+                output.appendLine('========== ev3dev-sysinfo ==========');
+                output.appendLine(sysinfo);
+                output.show();
+    
+                toastStatusBarMessage('System info retrieved.');
+            }
+            catch(err) {
+                vscode.window.showErrorMessage('An error occurred while getting system info: ' + (err.message || err));
+            }
+        });
     }
 
     iconPath = {


### PR DESCRIPTION
There might be room here to open this as an HTML preview or similar to make it feel more integrated, but to me the output window seems like a reasonable place for this.

The output is fairly self-explanatory, but for reference:

```
========== ev3dev-sysinfo ==========
Image file:         ev3dev-stretch-ev3-generic-2017-07-26
Kernel version:     4.9.39-ev3dev-1.3.0-ev3
Board:              LEGO MINDSTORMS EV3
Revision:           0000
Brickman:           0.9.0
ev3devKit:          0.5.1
```

p.s. I feel like the "revision" used to say something other than all zeroes... is that a Stretch thing? I think I recall you @dlech mentioning something about the serial number being blank.