### PR TITLE
Clean-up of return types, indentation and misc other things

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -175,7 +175,7 @@ export class Device extends vscode.Disposable {
     /**
      * Disconnect from the device.
      */
-    public disconnect() {
+    public disconnect(): void {
         this._isConnected = false;
         if (this.shellServer) {
             this.shellServer.close();
@@ -332,7 +332,7 @@ export class Device extends vscode.Disposable {
      * @param local The path to a local file.
      * @param remote The remote path where the file will be saved.
      */
-    put(local: string, remote: string): Promise<void> {
+    public put(local: string, remote: string): Promise<void> {
         return new Promise((resolve, reject) => {
             this.sftp.fastPut(local, remote, (err) => {
                 if (err) {
@@ -481,8 +481,8 @@ export class Device extends vscode.Disposable {
  * Quick pick item used in DeviceManager.pickDevice().
  */
 class ServiceItem implements vscode.QuickPickItem {
-    readonly label: string;
-    readonly description: string;
+    public readonly label: string;
+    public readonly description: string;
 
     constructor (public service: dnssd.Service) {
         this.label = service.name;

--- a/src/device.ts
+++ b/src/device.ts
@@ -175,7 +175,7 @@ export class Device extends vscode.Disposable {
     /**
      * Disconnect from the device.
      */
-    public disconnect(): void {
+    public disconnect() {
         this._isConnected = false;
         if (this.shellServer) {
             this.shellServer.close();
@@ -410,64 +410,64 @@ export class Device extends vscode.Disposable {
      */
     public static async pickDevice(): Promise<Device> {
         const selectedItem = await new Promise<ServiceItem>(async (resolve, reject) => {
-                // start browsing for devices
-                const dnssdClient = await Device.getDnssdClient();
-                const browser = await dnssdClient.browse({ service: 'sftp-ssh' });
-                const items = new Array<ServiceItem>();
-                let cancelSource: vscode.CancellationTokenSource;
-                let done = false;
+            // start browsing for devices
+            const dnssdClient = await Device.getDnssdClient();
+            const browser = await dnssdClient.browse({ service: 'sftp-ssh' });
+            const items = new Array<ServiceItem>();
+            let cancelSource: vscode.CancellationTokenSource;
+            let done = false;
 
-                // if a device is added or removed, cancel the quick-pick
-                // and then show a new one with the update list
-                browser.on('added', (service) => {
-                    if (service.txt['ev3dev.robot.home']) {
-                        // this looks like an ev3dev device
-                        const item = new ServiceItem(service);
-                        items.push(item);
-                        cancelSource.cancel();
-                    }
-                });
-                browser.on('removed', (service) => {
-                    const index = items.findIndex(si => si.service == service);
-                    if (index > -1) {
-                        items.splice(index, 1);
-                        cancelSource.cancel();
-                    }
-                });
-
-                // if there is a browser error, cancel the quick-pick and show
-                // an error message
-                browser.on('error', err => {
+            // if a device is added or removed, cancel the quick-pick
+            // and then show a new one with the update list
+            browser.on('added', (service) => {
+                if (service.txt['ev3dev.robot.home']) {
+                    // this looks like an ev3dev device
+                    const item = new ServiceItem(service);
+                    items.push(item);
                     cancelSource.cancel();
-                    browser.destroy();
-                    done = true;
-                    reject(err);
-                });
-
-                while (!done) {
-                    cancelSource = new vscode.CancellationTokenSource();
-                    // using this promise in the quick-pick will cause a progress
-                    // bar to show if there are no items.
-                    const list = new Promise<ServiceItem[]>((resolve, reject) => {
-                        if (items) {
-                            resolve(items);
-                        }
-                        else {
-                            reject();
-                        }
-                    })
-                    const selected = await vscode.window.showQuickPick(list, {
-                        ignoreFocusOut: true,
-                        placeHolder: "Searching for devices..."
-                    }, cancelSource.token);
-                    if (cancelSource.token.isCancellationRequested) {
-                        continue;
-                    }
-                    browser.destroy();
-                    done = true;
-                    resolve(selected);
                 }
             });
+            browser.on('removed', (service) => {
+                const index = items.findIndex(si => si.service == service);
+                if (index > -1) {
+                    items.splice(index, 1);
+                    cancelSource.cancel();
+                }
+            });
+
+            // if there is a browser error, cancel the quick-pick and show
+            // an error message
+            browser.on('error', err => {
+                cancelSource.cancel();
+                browser.destroy();
+                done = true;
+                reject(err);
+            });
+
+            while (!done) {
+                cancelSource = new vscode.CancellationTokenSource();
+                // using this promise in the quick-pick will cause a progress
+                // bar to show if there are no items.
+                const list = new Promise<ServiceItem[]>((resolve, reject) => {
+                    if (items) {
+                        resolve(items);
+                    }
+                    else {
+                        reject();
+                    }
+                })
+                const selected = await vscode.window.showQuickPick(list, {
+                    ignoreFocusOut: true,
+                    placeHolder: "Searching for devices..."
+                }, cancelSource.token);
+                if (cancelSource.token.isCancellationRequested) {
+                    continue;
+                }
+                browser.destroy();
+                done = true;
+                resolve(selected);
+            }
+        });
         if (!selectedItem) {
             // cancelled
             return null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ let ev3devBrowserProvider: Ev3devBrowserProvider;
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) : void {
+export function activate(context: vscode.ExtensionContext): void {
     output = vscode.window.createOutputChannel('ev3dev');
     resourceDir = context.asAbsolutePath('resources');
     helperExePath = context.asAbsolutePath(path.join('native', process.platform, 'helper'));
@@ -56,7 +56,7 @@ export function activate(context: vscode.ExtensionContext) : void {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {
+export function deactivate(): void {
     // The "temp" module should clean up automatically, but do this just in case.
     temp.cleanupSync();
 }
@@ -211,7 +211,7 @@ class Ev3devBrowserProvider extends vscode.Disposable implements vscode.TreeData
         });
     }
 
-    setDevice(device: Device) {
+    public setDevice(device: Device): void {
         if (this.device) {
             this.device.device.disconnect();
             this.device = null;
@@ -227,7 +227,7 @@ class Ev3devBrowserProvider extends vscode.Disposable implements vscode.TreeData
      *
      * Will prompt the user to select a device if there is not one already connected
      */
-    async getDevice(): Promise<Device> {
+    public async getDevice(): Promise<Device> {
         if (!this.device) {
             const connectNow = 'Connect Now';
             const result = await vscode.window.showErrorMessage('No ev3dev device is connected.', connectNow);
@@ -241,15 +241,15 @@ class Ev3devBrowserProvider extends vscode.Disposable implements vscode.TreeData
     /**
      * Gets the current device or null if no device is connected.
      */
-    getDeviceSync(): Device {
+    public getDeviceSync(): Device {
         return this.device && this.device.device;
     }
 
-    getTreeItem(element: DeviceTreeItem | File | CommandTreeItem): vscode.TreeItem {
+    public getTreeItem(element: DeviceTreeItem | File | CommandTreeItem): vscode.TreeItem {
         return element;
     }
 
-    getChildren(element?: DeviceTreeItem | File | CommandTreeItem): vscode.ProviderResult<DeviceTreeItem[] | File[] | CommandTreeItem[]> {
+    public getChildren(element?: DeviceTreeItem | File | CommandTreeItem): vscode.ProviderResult<DeviceTreeItem[] | File[] | CommandTreeItem[]> {
         if (!element) {
             return [this.device || this.noDeviceTreeItem];
         }
@@ -262,13 +262,13 @@ class Ev3devBrowserProvider extends vscode.Disposable implements vscode.TreeData
         return [];
     }
 
-    fireDeviceChanged() {
+    public fireDeviceChanged(): void {
         // not sure why, but if we pass device to fire(), vscode does not call
         // back to getTreeItem(), so we are refreshing the entire tree for now
         this._onDidChangeTreeData.fire();
     }
 
-    fireFileChanged(file: File) {
+    public fireFileChanged(file: File): void {
         this._onDidChangeTreeData.fire(file);
     }
 }
@@ -285,7 +285,7 @@ enum DeviceState {
 }
 
 class DeviceTreeItem extends vscode.TreeItem {
-    rootDirectory : File;
+    private rootDirectory : File;
 
     constructor(public readonly device: Device) {
         super(device.name);
@@ -304,7 +304,7 @@ class DeviceTreeItem extends vscode.TreeItem {
         }
     }
 
-    private handleConnectionState(state: DeviceState) {
+    private handleConnectionState(state: DeviceState): void {
         this.contextValue = state;
         setContext('ev3devBrowser.context.connected', false);
         this.collapsibleState = vscode.TreeItemCollapsibleState.None;
@@ -334,7 +334,7 @@ class DeviceTreeItem extends vscode.TreeItem {
         ev3devBrowserProvider.fireDeviceChanged();
     }
 
-    handleClick() {
+    public handleClick(): void {
         // Attempt to keep he collapsible state correct. If we don't do this,
         // strange things happen on a refresh.
         switch(this.collapsibleState) {
@@ -347,14 +347,14 @@ class DeviceTreeItem extends vscode.TreeItem {
         }
     }
 
-    openSshTerminal():void {
+    public openSshTerminal(): void {
         const term = vscode.window.createTerminal(`SSH: ${this.label}`,
             helperExePath,
             ['shell', this.device.shellPort.toString()]);
         term.show();
     }
     
-    async captureScreenshot() {
+    public async captureScreenshot(): Promise<void> {
         vscode.window.withProgress({
             location: vscode.ProgressLocation.Window,
             title: "Capturing screenshot..."
@@ -411,7 +411,7 @@ class DeviceTreeItem extends vscode.TreeItem {
         light: null
     };
 
-    async connect(): Promise<void> {
+    public async connect(): Promise<void> {
         try {
             await this.device.connect();
         }
@@ -420,7 +420,7 @@ class DeviceTreeItem extends vscode.TreeItem {
         }
     }
 
-    disconnect() {
+    public disconnect(): void {
         this.device.disconnect();
     }
 }
@@ -509,7 +509,7 @@ class File extends vscode.TreeItem {
         });
     }
 
-    handleClick() {
+    public handleClick(): void {
         // keep track of state so that it is preserved during refresh
         if (this.collapsibleState == vscode.TreeItemCollapsibleState.Expanded) {
             this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
@@ -532,7 +532,7 @@ class File extends vscode.TreeItem {
         }
     }
 
-    run() {
+    public run(): void {
         const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(vscode.workspace.rootPath));
         vscode.debug.startDebugging(folder, <vscode.DebugConfiguration> {
             type: 'ev3devBrowser',
@@ -542,7 +542,7 @@ class File extends vscode.TreeItem {
         });
     }
 
-    delete() {
+    public delete(): void {
         this.device.rm(this.path).then(() => {
             ev3devBrowserProvider.fireFileChanged(this.parent);
         }, err => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -262,13 +262,13 @@ class Ev3devBrowserProvider extends vscode.Disposable implements vscode.TreeData
         return [];
     }
 
-    fireDeviceChanged(): void {
+    fireDeviceChanged() {
         // not sure why, but if we pass device to fire(), vscode does not call
         // back to getTreeItem(), so we are refreshing the entire tree for now
         this._onDidChangeTreeData.fire();
     }
 
-    fireFileChanged(file: File): void {
+    fireFileChanged(file: File) {
         this._onDidChangeTreeData.fire(file);
     }
 }
@@ -334,7 +334,7 @@ class DeviceTreeItem extends vscode.TreeItem {
         ev3devBrowserProvider.fireDeviceChanged();
     }
 
-    handleClick(): void {
+    handleClick() {
         // Attempt to keep he collapsible state correct. If we don't do this,
         // strange things happen on a refresh.
         switch(this.collapsibleState) {
@@ -347,7 +347,7 @@ class DeviceTreeItem extends vscode.TreeItem {
         }
     }
 
-    openSshTerminal(): void {
+    openSshTerminal():void {
         const term = vscode.window.createTerminal(`SSH: ${this.label}`,
             helperExePath,
             ['shell', this.device.shellPort.toString()]);
@@ -420,7 +420,7 @@ class DeviceTreeItem extends vscode.TreeItem {
         }
     }
 
-    disconnect(): void {
+    disconnect() {
         this.device.disconnect();
     }
 }
@@ -509,7 +509,7 @@ class File extends vscode.TreeItem {
         });
     }
 
-    handleClick(): void {
+    handleClick() {
         // keep track of state so that it is preserved during refresh
         if (this.collapsibleState == vscode.TreeItemCollapsibleState.Expanded) {
             this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
@@ -532,7 +532,7 @@ class File extends vscode.TreeItem {
         }
     }
 
-    run(): void {
+    run() {
         const folder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(vscode.workspace.rootPath));
         vscode.debug.startDebugging(folder, <vscode.DebugConfiguration> {
             type: 'ev3devBrowser',
@@ -542,7 +542,7 @@ class File extends vscode.TreeItem {
         });
     }
 
-    delete(): void {
+    delete() {
         this.device.rm(this.path).then(() => {
             ev3devBrowserProvider.fireFileChanged(this.parent);
         }, err => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import { isArray } from 'util';
 
 const toastDuration = 5000;
 
-export function sanitizedDateString(date?: Date) {
+export function sanitizedDateString(date?: Date): string {
     const d = date || new Date();
     const pad = (num: number) => ("00" + num).slice(-2);
 
@@ -60,7 +60,7 @@ export async function verifyFileHeader(filePath: string, expectedHeader: Buffer 
     return header.compare(bufferExpectedHeader) == 0;
 }
 
-export function toastStatusBarMessage(message: string) {
+export function toastStatusBarMessage(message: string): void {
     vscode.window.setStatusBarMessage(message, toastDuration);
 }
 


### PR DESCRIPTION
These are mostly style changes to make the codebase consistent. I chose the styles I've seen, used and liked in other projects.

Also, I would like to add `public` wherever it was omitted, but that might be controversial. I like to add it in JS/TS because the default accessibility is the opposite of that in most other languages.