### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 
 os:
-  - osx
   - linux
 
 language: node_js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+
+os:
+  - osx
+  - linux
+
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
+
+install:
+  - npm install
+
+script:
+  - npm run vscode:prepublish

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os:
   - osx
   - linux
 
+language: node_js
+node_js: lts/*
+
 before_install:
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
@@ -16,3 +19,4 @@ install:
 
 script:
   - npm run vscode:prepublish
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,8 @@ os:
 language: node_js
 node_js: lts/*
 
-before_install:
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
-
 install:
-  - npm install
+  - npm install --no-optional
 
 script:
   - npm run vscode:prepublish
-  


### PR DESCRIPTION
https://travis-ci.org/WasabiFan/vscode-ev3dev-browser/builds/268983354

This was originally taken from here: https://code.visualstudio.com/docs/extensions/testing-extensions#_running-tests-automatically-on-travis-ci-build-machines

I modified it to specify the correct language and omitted running the tests given that we don't have any. ~~It might be nice to get AppVeyor builds running but I can't remember their licensing model.~~ #29