### PR TITLE
Present useful error when part of path given to mkdir_p exists but isn't a directory

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -308,14 +308,14 @@ export class Device extends vscode.Disposable {
 
     /**
      * Recursively create a directory (equivalent of mkdir -p).
-     * @param filePath the path of the directory
+     * @param dirPath the path of the directory
      */
-    public async mkdir_p(filePath: string): Promise<void> {
-        if (!path.posix.isAbsolute(filePath)) {
-            throw new URIError("The supplied file path must be absolute.");
+    public async mkdir_p(dirPath: string): Promise<void> {
+        if (!path.posix.isAbsolute(dirPath)) {
+            throw new Error("The supplied file path must be absolute.");
         }
 
-        const names = filePath.split('/');
+        const names = dirPath.split('/');
 
         // Leading slash produces empty first element
         names.shift();

--- a/src/device.ts
+++ b/src/device.ts
@@ -308,24 +308,26 @@ export class Device extends vscode.Disposable {
 
     /**
      * Recursively create a directory (equivalent of mkdir -p).
-     * @param path the path of the directory
+     * @param filePath the path of the directory
      */
-    public async mkdir_p(path: string): Promise<void> {
-        const names = path.split('/');
-
-        // If path had a preceding slash, remove the empty path segment
-        if(!names[0]) {
-            names.shift();
+    public async mkdir_p(filePath: string): Promise<void> {
+        if (!path.posix.isAbsolute(filePath)) {
+            throw new URIError("The supplied file path must be absolute.");
         }
+
+        const names = filePath.split('/');
+
+        // Leading slash produces empty first element
+        names.shift();
 
         let part = '';
         while (names.length) {
-            part += '/' + names.shift();
+            part = path.posix.join(part, names.shift());
             // Create the directory if it doesn't already exist
             try {
                 const stat = await this.stat(part);
                 if (!stat.isDirectory()) {
-                    throw new Error("Cannot create directory: part of path exists but isn't a directory");
+                    throw new Error(`Cannot create directory: "${part}" exists but isn't a directory`);
                 }
             }
             catch (err) {


### PR DESCRIPTION
Currently, if the `mkdir_p` method is given a path where a segment of it exists but isn't a directory, the sftp server returns error code 4 ("failure") with just the message "failure". With this change, we explain what went wrong.

Note that I also reversed the order of slash additions, so that `mkdir` is called without a trailing slash. This is because the sftp `stat` call returns that the file doesn't exist if the trailing slash is included; both `stat` and `mkdir` operate as expected without it, with the added benefit that `stat` succeeds instead of claiming that the file doesn't exist. This way, we can handle it intelligently.