### PR TITLE
Register as a default debugger for Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the "ev3dev-browser" extension will be documented in this
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+### Added
+- ev3dev remote debugger is now a default debugger for Python files
+
 ## 1.1.0 - 2020-03-07
 ### Added
 - New "pause" button on debugger that sends SIGINT to remote process

--- a/package.json
+++ b/package.json
@@ -211,6 +211,9 @@
                 "label": "ev3dev",
                 "program": "./out/debugServer.js",
                 "runtime": "node",
+                "languages": [
+                    "python"
+                ],
                 "configurationAttributes": {
                     "launch": {
                         "required": [


### PR DESCRIPTION
As it is, it's hard to discover this extension's debugger; it seems there are only very particular circumstances where vscode will auto-detect that this debugger exists and recommend it. By setting this debugger as a Python default, when selecting one of the options that has you choose a debug provider, rather than assuming you want to use the Python extension it will provide two options:

![image](https://user-images.githubusercontent.com/3310349/77388261-de230300-6d4c-11ea-87df-7d02f7465f85.png)

Clicking "python" does the same thing as it used to, while "ev3dev" selects ours. I think this is a good way to make sure this debugger is accessible. As far as I can tell, the only other way right now is to manually type the debugger ID into a launch file.