### PR TITLE
added a download single file button and a download single folder button

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "activationEvents": [
         "onView:ev3devBrowser",
         "onDebugResolve:ev3devBrowser",
-        "onCommand:ev3devBrowser.action.pickDevice"
+        "onCommand:ev3devBrowser.action.pickDevice",
+        "onCommand:ev3devBrowser.action.uploadSingleFile"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -137,8 +138,7 @@
                 }
             }
         },
-        "commands": [
-            {
+        "commands": [{
                 "command": "ev3devBrowser.deviceTreeItem.openSshTerminal",
                 "title": "Open SSH Terminal"
             },
@@ -204,70 +204,69 @@
                     "light": "resources/icons/light/refresh.svg"
                 },
                 "category": "ev3dev"
-            }
-        ],
-        "debuggers": [
+            },
             {
-                "type": "ev3devBrowser",
-                "label": "ev3dev",
-                "program": "./out/debugServer.js",
-                "runtime": "node",
-                "languages": [
-                    "python"
-                ],
-                "configurationAttributes": {
-                    "launch": {
-                        "required": [
-                            "program"
-                        ],
-                        "properties": {
-                            "program": {
-                                "type": "string",
-                                "description": "Absolute path to an executable file on the remote device.",
-                                "default": "/home/robot/myproject/myprogram"
-                            },
-                            "interactiveTerminal": {
-                                "type": "boolean",
-                                "description": "When true, program will be run in a new interactive terminal, when false the output pane will be used instead.",
-                                "default": false
-                            }
-                        }
-                    }
-                },
-                "configurationSnippets": [
-                    {
-                        "label": "ev3dev: Download and Run",
-                        "description": "Configuration for downloading and running a program on an ev3dev device.",
-                        "body": {
-                            "name": "Download and Run",
-                            "type": "ev3devBrowser",
-                            "request": "launch",
-                            "program": "^\"/home/robot/\\${workspaceFolderBasename}/${1:myprogram}\"",
-                            "interactiveTerminal": false
-                        }
-                    }
-                ],
-                "initialConfigurations": [
-                    {
-                        "name": "Download and Run current file",
-                        "type": "ev3devBrowser",
-                        "request": "launch",
-                        "program": "/home/robot/${workspaceFolderBasename}/${relativeFile}",
-                        "interactiveTerminal": true
-                    },
-                    {
-                        "name": "Download and Run my-program",
-                        "type": "ev3devBrowser",
-                        "request": "launch",
-                        "program": "/home/robot/${workspaceFolderBasename}/my-program (replace 'my-program' with the actual path)",
-                        "interactiveTerminal": true
-                    }
-                ]
+                "command": "ev3devBrowser.action.uploadSingleFile",
+                "title": "upload this file to connected ev3",
+                "category": "ev3dev"
             }
         ],
-        "menus": {
-            "commandPalette": [
+        "debuggers": [{
+            "type": "ev3devBrowser",
+            "label": "ev3dev",
+            "program": "./out/debugServer.js",
+            "runtime": "node",
+            "languages": [
+                "python"
+            ],
+            "configurationAttributes": {
+                "launch": {
+                    "required": [
+                        "program"
+                    ],
+                    "properties": {
+                        "program": {
+                            "type": "string",
+                            "description": "Absolute path to an executable file on the remote device.",
+                            "default": "/home/robot/myproject/myprogram"
+                        },
+                        "interactiveTerminal": {
+                            "type": "boolean",
+                            "description": "When true, program will be run in a new interactive terminal, when false the output pane will be used instead.",
+                            "default": false
+                        }
+                    }
+                }
+            },
+            "configurationSnippets": [{
+                "label": "ev3dev: Download and Run",
+                "description": "Configuration for downloading and running a program on an ev3dev device.",
+                "body": {
+                    "name": "Download and Run",
+                    "type": "ev3devBrowser",
+                    "request": "launch",
+                    "program": "^\"/home/robot/\\${workspaceFolderBasename}/${1:myprogram}\"",
+                    "interactiveTerminal": false
+                }
+            }],
+            "initialConfigurations": [{
+                    "name": "Download and Run current file",
+                    "type": "ev3devBrowser",
+                    "request": "launch",
+                    "program": "/home/robot/${workspaceFolderBasename}/${relativeFile}",
+                    "interactiveTerminal": true
+                },
                 {
+                    "name": "Download and Run my-program",
+                    "type": "ev3devBrowser",
+                    "request": "launch",
+                    "program": "/home/robot/${workspaceFolderBasename}/my-program (replace 'my-program' with the actual path)",
+                    "interactiveTerminal": true
+                }
+            ]
+        }],
+        "menus": {
+            "commandPalette": [{
                     "command": "ev3devBrowser.action.pickDevice"
                 },
                 {
@@ -323,8 +322,7 @@
                     "when": "false"
                 }
             ],
-            "view/title": [
-                {
+            "view/title": [{
                     "command": "ev3devBrowser.action.refresh",
                     "group": "navigation",
                     "when": "view == ev3devBrowser && ev3devBrowser.context.connected"
@@ -335,8 +333,7 @@
                     "when": "view == ev3devBrowser && ev3devBrowser.context.connected"
                 }
             ],
-            "view/item/context": [
-                {
+            "view/item/context": [{
                     "command": "ev3devBrowser.deviceTreeItem.reconnect",
                     "when": "view == ev3devBrowser && viewItem == ev3devBrowser.device.disconnected",
                     "group": "group@0"
@@ -411,15 +408,18 @@
                     "when": "view == ev3devBrowser && viewItem == ev3devBrowser.file",
                     "group": "group@10"
                 }
-            ]
+            ],
+            "explorer/context": [{
+                "command": "ev3devBrowser.action.uploadSingleFile",
+                "group": "navigation",
+                "when": "!explorerResourceIsFolder"
+            }]
         },
         "views": {
-            "explorer": [
-                {
-                    "id": "ev3devBrowser",
-                    "name": "ev3dev device browser"
-                }
-            ]
+            "explorer": [{
+                "id": "ev3devBrowser",
+                "name": "ev3dev device browser"
+            }]
         }
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -206,8 +206,13 @@
                 "category": "ev3dev"
             },
             {
-                "command": "ev3devBrowser.action.uploadSingleFile",
-                "title": "upload this file to connected ev3",
+                "command": "ev3devBrowser.action.downloadSingleFile",
+                "title": "download this file to ev3 robot",
+                "category": "ev3dev"
+            },
+            {
+                "command": "ev3devBrowser.action.downloadSingleFolder",
+                "title": "download this folder to ev3 robot",
                 "category": "ev3dev"
             }
         ],
@@ -410,17 +415,31 @@
                 }
             ],
             "explorer/context": [{
-                "command": "ev3devBrowser.action.uploadSingleFile",
-                "group": "navigation",
-                "when": "!explorerResourceIsFolder"
-            }]
+                "submenu": "explorer/context/ev3devBrowser",
+                "group": "ev3devBrowser.editorGroup"
+            }],
+            "explorer/context/ev3devBrowser": [{
+                    "command": "ev3devBrowser.action.downloadSingleFile",
+                    "group": "group@1",
+                    "when": "!explorerResourceIsFolder"
+                },
+                {
+                    "command": "ev3devBrowser.action.downloadSingleFolder",
+                    "group": "group@2",
+                    "when": "explorerResourceIsFolder"
+                }
+            ]
         },
         "views": {
             "explorer": [{
                 "id": "ev3devBrowser",
                 "name": "ev3dev device browser"
             }]
-        }
+        },
+        "submenus": [{
+            "label": "ev3dev Browser",
+            "id": "explorer/context/ev3devBrowser"
+        }]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -435,7 +435,7 @@ async function download(folder: vscode.WorkspaceFolder, device: Device): Promise
                 //   should be executable since Windows doesn't know about
                 //   POSIX file permissions.
                 let mode: string;
-                if (await verifyFileHeader(f.fsPath, new Buffer('#!/'))) {
+                if (await verifyFileHeader(f.fsPath, Buffer.from('#!/'))) {
                     mode = '755';
                 }
                 else {
@@ -447,7 +447,7 @@ async function download(folder: vscode.WorkspaceFolder, device: Device): Promise
 
                         // So, we check to see the file uses ELF format, if
                         // so, make it executable.
-                        if (await verifyFileHeader(f.fsPath, new Buffer('\x7fELF'))) {
+                        if (await verifyFileHeader(f.fsPath, Buffer.from('\x7fELF'))) {
                             stat.mode |= S_IXUSR;
                         }
                     }
@@ -482,7 +482,6 @@ async function download(folder: vscode.WorkspaceFolder, device: Device): Promise
 
 // ask for a file directory, then upload single file to ev3
 async function downloadSingleFileCommand(f: vscode.Uri) {
-    console.log(f);
     try {
         if (!f) {
             throw new Error("no file detected");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -494,12 +494,15 @@ async function uploadSingleFileCommand(f: vscode.Uri) {
             throw new Error("Device is not connected.");
         }
         await vscode.workspace.saveAll();
+        const config = vscode.workspace.getConfiguration('ev3devBrowser.download');
+        const projectDir = config.get<string>('directory');
         const inputboxOptions = {
             ignoreFocusOut: true,
-            placeHolder: "folder to place file in",
+            placeHolder: projectDir || "enter folder name to place file in",
             title: `Where should ${path.basename(f.fsPath)} be placed?`
         };
-        const inputFilePath = await vscode.window.showInputBox(inputboxOptions);
+        let inputFilePath = await vscode.window.showInputBox(inputboxOptions);
+        inputFilePath = (inputFilePath || projectDir) || "";
         if (inputFilePath == undefined) {
             throw new Error("no file path given");
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -507,12 +507,6 @@ async function downloadSingleFileCommand(f: vscode.Uri) {
         if (inputFilePath == undefined) {
             throw new Error("no file path given");
         }
-        const relativePath = vscode.workspace.asRelativePath(f, false);
-        const basename = path.basename(f.fsPath);
-        let relativeDir = path.dirname(relativePath)
-        if (path === path.win32) {
-            relativeDir = relativeDir.replace(path.win32.sep, path.posix.sep);
-        }
         const remoteDir = path.posix.join(device.homeDirectoryPath, inputFilePath);
         await downloadSingleFile(f, remoteDir, device);
     }
@@ -539,8 +533,8 @@ async function downloadSingleFile(f: vscode.Uri, remoteDir: string, device: Devi
         throw new Error("lost connection");
     }
     await device.mkdir_p(remoteDir);
-    console.log(remoteDir);
-    await device.put(f.fsPath, path.posix.resolve(remoteDir, path.basename(f.fsPath)), mode);
+    const remotePath = path.posix.resolve(remoteDir, path.basename(f.fsPath));
+    await device.put(f.fsPath, remotePath, mode);
     ev3devBrowserProvider.fireDeviceChanged();
     vscode.window.showInformationMessage("upload complete.");
     return;
@@ -569,7 +563,7 @@ async function downloadSingleFolderCommand(f: vscode.Uri) {
         let inputFilePath = await vscode.window.showInputBox(inputboxOptions);
         inputFilePath = (inputFilePath || projectDir) || "";
         if (inputFilePath == undefined) {
-            throw new Error("no file path given");
+            throw new Error("no path given");
         }
         const remoteDir = path.posix.join(device.homeDirectoryPath, inputFilePath);
         await downloadSingleFolder(f, remoteDir, device);
@@ -594,7 +588,6 @@ async function downloadSingleFolder(folder: vscode.Uri, remDir: string, device: 
                 vscode.commands.executeCommand('workbench.action.openSettings2');
             }
         });
-
         // "cancel" the download
         return false;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -535,7 +535,8 @@ async function uploadSingleFile(f: vscode.Uri, remoteDir: string, device: Device
         throw new Error("lost connection");
     }
     await device.mkdir_p(remoteDir);
-    await device.put(f.fsPath, path.basename(f.fsPath), mode);
+    console.log(remoteDir);
+    await device.put(f.fsPath, path.posix.resolve(remoteDir, path.basename(f.fsPath)), mode);
     ev3devBrowserProvider.fireDeviceChanged();
     vscode.window.showInformationMessage("upload complete.");
     return;


### PR DESCRIPTION
When you right click any file on the editor, you can now find a "upload this file to connected ev3" button. Then, it will ask you which folder the file should be placed in (leaving it blank just places it in `home/robot`), then it will copy the file from your computer onto the ev3 in that folder. Just a Qol feature I made because I didn't want to upload my entire workspace.