### PR TITLE
Fix compatibility with modern VS Code and Node runtimes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ev3dev-browser",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ev3dev-browser",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "license": "MIT",
             "dependencies": {
                 "bonjour": "^3.5.0",
@@ -29,6 +29,7 @@
                 "@types/vscode": "^1.39.0",
                 "@types/zen-observable": "^0.5.3",
                 "esbuild": "^0.17.14",
+                "patch-package": "^8.0.1",
                 "tslint": "^5.8.0",
                 "typescript": "^4.9.5",
                 "vscode-test": "^1.3.0"
@@ -494,6 +495,13 @@
             "integrity": "sha512-sW6xN96wUak4tgc89d0tbTg7QDGYhGv5hvQIS6h4mRCd8h2btiZ80loPU8cyLwsBbA4ZeQt0FjvUhJ4rNhdsGg==",
             "dev": true
         },
+        "node_modules/@yarnpkg/lockfile": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
         "node_modules/abstract-socket": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/abstract-socket/-/abstract-socket-2.1.1.tgz",
@@ -593,6 +601,19 @@
                 "concat-map": "0.0.1"
             }
         },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/buffer-indexof": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
@@ -607,6 +628,56 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -619,6 +690,22 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/color-convert": {
@@ -651,6 +738,21 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "node_modules/cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/dbus-next": {
             "version": "0.8.2",
@@ -749,6 +851,24 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -791,6 +911,21 @@
                 "buffer-indexof": "^1.0.0"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -818,6 +953,39 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/es-to-primitive": {
@@ -916,10 +1084,48 @@
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
             "optional": true
         },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-yarn-workspace-root": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "micromatch": "^4.0.2"
+            }
+        },
         "node_modules/from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+        },
+        "node_modules/fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
@@ -927,9 +1133,52 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/glob": {
             "version": "7.1.6",
@@ -949,6 +1198,26 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/has": {
             "version": "1.0.3",
@@ -970,15 +1239,42 @@
                 "node": ">=4"
             }
         },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/hexy": {
@@ -1064,6 +1360,32 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
         "node_modules/is-regex": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -1092,6 +1414,33 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1115,6 +1464,83 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-2.0.5.tgz",
             "integrity": "sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ=="
+        },
+        "node_modules/json-stable-stringify": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+            "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "isarray": "^2.0.5",
+                "jsonify": "^0.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+            "dev": true,
+            "license": "Public Domain",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/klaw-sync": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.11"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=8.6"
+            }
         },
         "node_modules/minimatch": {
             "version": "3.1.2",
@@ -1228,12 +1654,158 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/patch-package": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+            "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@yarnpkg/lockfile": "^1.1.0",
+                "chalk": "^4.1.2",
+                "ci-info": "^3.7.0",
+                "cross-spawn": "^7.0.3",
+                "find-yarn-workspace-root": "^2.0.0",
+                "fs-extra": "^10.0.0",
+                "json-stable-stringify": "^1.0.2",
+                "klaw-sync": "^6.0.0",
+                "minimist": "^1.2.6",
+                "open": "^7.4.2",
+                "semver": "^7.5.3",
+                "slash": "^2.0.0",
+                "tmp": "^0.2.4",
+                "yaml": "^2.2.2"
+            },
+            "bin": {
+                "patch-package": "index.js"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">5"
+            }
+        },
+        "node_modules/patch-package/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/patch-package/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/patch-package/node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/patch-package/node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/patch-package/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/patch-package/node_modules/semver": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/patch-package/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/path-parse": {
@@ -1248,6 +1820,19 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dependencies": {
                 "through": "~2.3"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/regexp.prototype.flags": {
@@ -1309,6 +1894,57 @@
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "bin": {
                 "semver": "bin/semver"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/sprintf-js": {
@@ -1438,6 +2074,29 @@
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
         },
+        "node_modules/tmp": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.14"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
         "node_modules/tslib": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -1500,6 +2159,16 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/vscode-debugadapter": {
             "version": "1.40.0",
             "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.40.0.tgz",
@@ -1531,6 +2200,22 @@
                 "node": ">=8.9.3"
             }
         },
+        "node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1542,6 +2227,22 @@
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "engines": {
                 "node": ">=4.0"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/zen-observable": {
@@ -1806,6 +2507,12 @@
             "integrity": "sha512-sW6xN96wUak4tgc89d0tbTg7QDGYhGv5hvQIS6h4mRCd8h2btiZ80loPU8cyLwsBbA4ZeQt0FjvUhJ4rNhdsGg==",
             "dev": true
         },
+        "@yarnpkg/lockfile": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+            "dev": true
+        },
         "abstract-socket": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/abstract-socket/-/abstract-socket-2.1.1.tgz",
@@ -1892,6 +2599,15 @@
                 "concat-map": "0.0.1"
             }
         },
+        "braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.1.1"
+            }
+        },
         "buffer-indexof": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
@@ -1903,6 +2619,38 @@
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
             "dev": true
         },
+        "call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            }
+        },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
+        "call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            }
+        },
         "chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1913,6 +2661,12 @@
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
             }
+        },
+        "ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "dev": true
         },
         "color-convert": {
             "version": "1.9.3",
@@ -1944,6 +2698,17 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "cross-spawn": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            }
         },
         "dbus-next": {
             "version": "0.8.2",
@@ -2033,6 +2798,17 @@
                 "regexp.prototype.flags": "^1.2.0"
             }
         },
+        "define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "requires": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            }
+        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -2069,6 +2845,17 @@
                 "buffer-indexof": "^1.0.0"
             }
         },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
+        },
         "duplexer": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -2090,6 +2877,27 @@
                 "object.assign": "^4.1.0",
                 "string.prototype.trimleft": "^2.1.1",
                 "string.prototype.trimright": "^2.1.1"
+            }
+        },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true
+        },
+        "es-object-atoms": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
+            "requires": {
+                "es-errors": "^1.3.0"
             }
         },
         "es-to-primitive": {
@@ -2165,10 +2973,39 @@
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
             "optional": true
         },
+        "fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
+        },
+        "find-yarn-workspace-root": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+            "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+            "dev": true,
+            "requires": {
+                "micromatch": "^4.0.2"
+            }
+        },
         "from": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+        },
+        "fs-extra": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -2176,9 +3013,37 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            }
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
         },
         "glob": {
             "version": "7.1.6",
@@ -2192,6 +3057,18 @@
                 "once": "^1.3.0",
                 "path-is-absolute": "^1.0.0"
             }
+        },
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "has": {
             "version": "1.0.3",
@@ -2207,10 +3084,28 @@
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
+        "has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "requires": {
+                "es-define-property": "^1.0.0"
+            }
+        },
         "has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "hasown": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
         },
         "hexy": {
             "version": "0.2.11",
@@ -2271,6 +3166,18 @@
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
         },
+        "is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
+        },
         "is-regex": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -2286,6 +3193,27 @@
             "requires": {
                 "has-symbols": "^1.0.1"
             }
+        },
+        "is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "requires": {
+                "is-docker": "^2.0.0"
+            }
+        },
+        "isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -2307,6 +3235,60 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-2.0.5.tgz",
             "integrity": "sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ=="
+        },
+        "json-stable-stringify": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+            "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "isarray": "^2.0.5",
+                "jsonify": "^0.0.1",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "jsonfile": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+            "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            }
+        },
+        "jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+            "dev": true
+        },
+        "klaw-sync": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11"
+            }
+        },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.3",
+                "picomatch": "^2.3.1"
+            }
         },
         "minimatch": {
             "version": "3.1.2",
@@ -2393,10 +3375,105 @@
                 "wrappy": "1"
             }
         },
+        "open": {
+            "version": "7.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+            "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+            "dev": true,
+            "requires": {
+                "is-docker": "^2.0.0",
+                "is-wsl": "^2.1.1"
+            }
+        },
+        "patch-package": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+            "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+            "dev": true,
+            "requires": {
+                "@yarnpkg/lockfile": "^1.1.0",
+                "chalk": "^4.1.2",
+                "ci-info": "^3.7.0",
+                "cross-spawn": "^7.0.3",
+                "find-yarn-workspace-root": "^2.0.0",
+                "fs-extra": "^10.0.0",
+                "json-stable-stringify": "^1.0.2",
+                "klaw-sync": "^6.0.0",
+                "minimist": "^1.2.6",
+                "open": "^7.4.2",
+                "semver": "^7.5.3",
+                "slash": "^2.0.0",
+                "tmp": "^0.2.4",
+                "yaml": "^2.2.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.8.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+                    "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
         },
         "path-parse": {
             "version": "1.0.7",
@@ -2411,6 +3488,12 @@
             "requires": {
                 "through": "~2.3"
             }
+        },
+        "picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true
         },
         "regexp.prototype.flags": {
             "version": "1.3.0",
@@ -2457,6 +3540,41 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "requires": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            }
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
+        },
+        "slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -2552,6 +3670,21 @@
             "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
         },
+        "tmp": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+            "dev": true
+        },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
         "tslib": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -2594,6 +3727,12 @@
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
+        "universalify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true
+        },
         "vscode-debugadapter": {
             "version": "1.40.0",
             "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.40.0.tgz",
@@ -2619,6 +3758,15 @@
                 "rimraf": "^2.6.3"
             }
         },
+        "which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2628,6 +3776,12 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+        },
+        "yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true
         },
         "zen-observable": {
             "version": "0.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@types/zen-observable": "^0.5.3",
                 "esbuild": "^0.17.14",
                 "tslint": "^5.8.0",
-                "typescript": "^3.7.4",
+                "typescript": "^4.9.5",
                 "vscode-test": "^1.3.0"
             },
             "engines": {
@@ -1487,10 +1487,11 @@
             }
         },
         "node_modules/typescript": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -2588,9 +2589,9 @@
             }
         },
         "typescript": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true
         },
         "vscode-debugadapter": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "ev3dev-browser",
     "displayName": "ev3dev-browser",
     "description": "Browse for ev3dev devices",
+    "postinstall": "patch-package",
     "icon": "resources/icons/ev3dev-logo.png",
     "version": "1.2.2",
     "publisher": "ev3dev",
@@ -442,6 +443,7 @@
         "@types/vscode": "^1.39.0",
         "@types/zen-observable": "^0.5.3",
         "esbuild": "^0.17.14",
+        "patch-package": "^8.0.1",
         "tslint": "^5.8.0",
         "typescript": "^4.9.5",
         "vscode-test": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "ev3dev-browser",
     "description": "Browse for ev3dev devices",
     "icon": "resources/icons/ev3dev-logo.png",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "publisher": "ev3dev",
     "license": "MIT",
     "repository": {
@@ -443,7 +443,7 @@
         "@types/zen-observable": "^0.5.3",
         "esbuild": "^0.17.14",
         "tslint": "^5.8.0",
-        "typescript": "^3.7.4",
+        "typescript": "^4.9.5",
         "vscode-test": "^1.3.0"
     },
     "dependencies": {

--- a/patches/ssh2-streams+0.1.20.patch
+++ b/patches/ssh2-streams+0.1.20.patch
@@ -1,0 +1,1300 @@
+diff --git a/node_modules/ssh2-streams/lib/sftp.js b/node_modules/ssh2-streams/lib/sftp.js
+index 9e93200..4774740 100644
+--- a/node_modules/ssh2-streams/lib/sftp.js
++++ b/node_modules/ssh2-streams/lib/sftp.js
+@@ -6,7 +6,9 @@ var WritableStream = require('stream').Writable;
+ var constants = require('fs').constants || process.binding('constants');
+ var util = require('util');
+ var inherits = util.inherits;
+-var isDate = util.isDate;
++var isDate = function (v) {
++  return Object.prototype.toString.call(v) === '[object Date]';
++};
+ var listenerCount = require('events').EventEmitter.listenerCount;
+ var fs = require('fs');
+ 
+@@ -32,7 +34,7 @@ var STATUS_CODE = {
+   CONNECTION_LOST: 7,
+   OP_UNSUPPORTED: 8
+ };
+-Object.keys(STATUS_CODE).forEach(function(key) {
++Object.keys(STATUS_CODE).forEach(function (key) {
+   STATUS_CODE[STATUS_CODE[key]] = key;
+ });
+ var STATUS_CODE_STR = {
+@@ -70,7 +72,7 @@ var REQUEST = {
+   SYMLINK: 20,
+   EXTENDED: 200
+ };
+-Object.keys(REQUEST).forEach(function(key) {
++Object.keys(REQUEST).forEach(function (key) {
+   REQUEST[REQUEST[key]] = key;
+ });
+ 
+@@ -83,7 +85,7 @@ var RESPONSE = {
+   ATTRS: 105,
+   EXTENDED: 201
+ };
+-Object.keys(RESPONSE).forEach(function(key) {
++Object.keys(RESPONSE).forEach(function (key) {
+   RESPONSE[RESPONSE[key]] = key;
+ });
+ 
+@@ -100,11 +102,11 @@ SFTPStream.OPEN_MODE = OPEN_MODE;
+ var MAX_PKT_LEN = 34000;
+ var MAX_REQID = Math.pow(2, 32) - 1;
+ var CLIENT_VERSION_BUFFER = new Buffer([0, 0, 0, 5 /* length */,
+-                                        REQUEST.INIT,
+-                                        0, 0, 0, 3 /* version */]);
++  REQUEST.INIT,
++  0, 0, 0, 3 /* version */]);
+ var SERVER_VERSION_BUFFER = new Buffer([0, 0, 0, 5 /* length */,
+-                                        RESPONSE.VERSION,
+-                                        0, 0, 0, 3 /* version */]);
++  RESPONSE.VERSION,
++  0, 0, 0, 3 /* version */]);
+ /*
+   http://tools.ietf.org/html/draft-ietf-secsh-filexfer-02:
+ 
+@@ -121,7 +123,7 @@ var SERVER_VERSION_BUFFER = new Buffer([0, 0, 0, 5 /* length */,
+ var RE_OPENSSH = /^SSH-2.0-(?:OpenSSH|dropbear)/;
+ var OPENSSH_MAX_DATA_LEN = (256 * 1024) - (2 * 1024)/*account for header data*/;
+ 
+-function DEBUG_NOOP(msg) {}
++function DEBUG_NOOP(msg) { }
+ 
+ function SFTPStream(cfg, remoteIdentRaw) {
+   if (typeof cfg === 'string' && !remoteIdentRaw) {
+@@ -133,8 +135,8 @@ function SFTPStream(cfg, remoteIdentRaw) {
+ 
+   TransformStream.call(this, {
+     highWaterMark: (typeof cfg.highWaterMark === 'number'
+-                    ? cfg.highWaterMark
+-                    : 32 * 1024)
++      ? cfg.highWaterMark
++      : 32 * 1024)
+   });
+ 
+   this.debug = (typeof cfg.debug === 'function' ? cfg.debug : DEBUG_NOOP);
+@@ -158,7 +160,7 @@ function SFTPStream(cfg, remoteIdentRaw) {
+   };
+ 
+   var self = this;
+-  this.on('end', function() {
++  this.on('end', function () {
+     self.readable = false;
+   }).on('finish', onFinish)
+     .on('prefinish', onFinish);
+@@ -173,7 +175,7 @@ function SFTPStream(cfg, remoteIdentRaw) {
+ inherits(SFTPStream, TransformStream);
+ 
+ SFTPStream.prototype.__read = TransformStream.prototype._read;
+-SFTPStream.prototype._read = function(n) {
++SFTPStream.prototype._read = function (n) {
+   if (this._needContinue) {
+     this._needContinue = false;
+     this.emit('continue');
+@@ -181,7 +183,7 @@ SFTPStream.prototype._read = function(n) {
+   return this.__read(n);
+ };
+ SFTPStream.prototype.__push = TransformStream.prototype.push;
+-SFTPStream.prototype.push = function(chunk, encoding) {
++SFTPStream.prototype.push = function (chunk, encoding) {
+   if (!this.readable)
+     return false;
+   if (chunk === null)
+@@ -191,7 +193,7 @@ SFTPStream.prototype.push = function(chunk, encoding) {
+   return ret;
+ };
+ 
+-SFTPStream.prototype._cleanup = function(callback) {
++SFTPStream.prototype._cleanup = function (callback) {
+   var state = this._state;
+ 
+   state.pktBuf = undefined; // give GC something to do
+@@ -220,7 +222,7 @@ SFTPStream.prototype._cleanup = function(callback) {
+   }
+ };
+ 
+-SFTPStream.prototype._transform = function(chunk, encoding, callback) {
++SFTPStream.prototype._transform = function (chunk, encoding, callback) {
+   var state = this._state;
+   var server = this.server;
+   var status = state.status;
+@@ -253,9 +255,9 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+       chunkLeft = (chunkLen - chunkPos);
+       if (pktLeft <= chunkLeft) {
+         chunk.copy(pktBuf,
+-                   pktBuf.length - pktLeft,
+-                   chunkPos,
+-                   chunkPos + pktLeft);
++          pktBuf.length - pktLeft,
++          chunkPos,
++          chunkPos + pktLeft);
+         chunkPos += pktLeft;
+         pktLeft = 0;
+         buffer = pktBuf;
+@@ -285,10 +287,10 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+             status = 'bad_pkt';
+           } else if (pktLeft > MAX_PKT_LEN) {
+             var msg = 'Packet length ('
+-                      + pktLeft
+-                      + ') exceeds max length ('
+-                      + MAX_PKT_LEN
+-                      + ')';
++              + pktLeft
++              + ') exceeds max length ('
++              + MAX_PKT_LEN
++              + ')';
+             debug('DEBUG[SFTP]: Parser: ' + msg);
+             this._cleanup(false);
+             return callback(new Error(msg));
+@@ -350,7 +352,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+           if (state.extensions[extname])
+             state.extensions[extname].push(extdata);
+           else
+-            state.extensions[extname] = [ extdata ];
++            state.extensions[extname] = [extdata];
+         }
+ 
+         this.emit('ready');
+@@ -399,17 +401,17 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+                     return;
+                   if ((buffer._pos + 4) < buffer.length) {
+                     lang = readString(buffer,
+-                                      buffer._pos,
+-                                      'ascii',
+-                                      this,
+-                                      callback);
++                      buffer._pos,
++                      'ascii',
++                      this,
++                      callback);
+                     if (lang === false)
+                       return;
+                   }
+                 }
+                 var err = new Error(msg
+-                                    || STATUS_CODE_STR[code]
+-                                    || 'Unknown status');
++                  || STATUS_CODE_STR[code]
++                  || 'Unknown status');
+                 err.code = code;
+                 err.lang = lang;
+                 cb(err);
+@@ -458,7 +460,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+               if (namesLen === false)
+                 return;
+               var names = [],
+-                  longname;
++                longname;
+               buffer._pos = 8;
+               for (var i = 0; i < namesLen; ++i) {
+                 // we are going to assume UTF-8 for filenames despite the SFTPv3
+@@ -466,19 +468,19 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+                 // versions of the protocol all explicitly specify UTF-8 for
+                 // filenames
+                 filename = readString(buffer,
+-                                      buffer._pos,
+-                                      'utf8',
+-                                      this,
+-                                      callback);
++                  buffer._pos,
++                  'utf8',
++                  this,
++                  callback);
+                 if (filename === false)
+                   return;
+                 // `longname` only exists in SFTPv3 and since it typically will
+                 // contain the filename, we assume it is also UTF-8
+                 longname = readString(buffer,
+-                                      buffer._pos,
+-                                      'utf8',
+-                                      this,
+-                                      callback);
++                  buffer._pos,
++                  'utf8',
++                  this,
++                  callback);
+                 if (longname === false)
+                   return;
+                 attrs = readAttrs(buffer, buffer._pos, this, callback);
+@@ -564,7 +566,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+                     if (stats.f_namemax === false)
+                       return;
+                     cb(undefined, stats);
+-                  break;
++                    break;
+                 }
+               }
+               // XXX: at least provide the raw buffer data to the callback in
+@@ -599,8 +601,8 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+                 return;
+               this.emit(evName, id, filename, pflags, attrs);
+             } else if (pktType === REQUEST.CLOSE
+-                       || pktType === REQUEST.FSTAT
+-                       || pktType === REQUEST.READDIR) {
++              || pktType === REQUEST.FSTAT
++              || pktType === REQUEST.READDIR) {
+               /*
+                 string     handle
+               */
+@@ -641,12 +643,12 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+                 return;
+               this.emit(evName, id, handle, offset, data);
+             } else if (pktType === REQUEST.LSTAT
+-                       || pktType === REQUEST.STAT
+-                       || pktType === REQUEST.OPENDIR
+-                       || pktType === REQUEST.REMOVE
+-                       || pktType === REQUEST.RMDIR
+-                       || pktType === REQUEST.REALPATH
+-                       || pktType === REQUEST.READLINK) {
++              || pktType === REQUEST.STAT
++              || pktType === REQUEST.OPENDIR
++              || pktType === REQUEST.REMOVE
++              || pktType === REQUEST.RMDIR
++              || pktType === REQUEST.REALPATH
++              || pktType === REQUEST.READLINK) {
+               /*
+                 string     path
+               */
+@@ -655,7 +657,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+                 return;
+               this.emit(evName, id, path);
+             } else if (pktType === REQUEST.SETSTAT
+-                       || pktType === REQUEST.MKDIR) {
++              || pktType === REQUEST.MKDIR) {
+               /*
+                 string     path
+                 ATTRS      attrs
+@@ -680,7 +682,7 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+                 return;
+               this.emit(evName, id, handle, attrs);
+             } else if (pktType === REQUEST.RENAME
+-                       || pktType === REQUEST.SYMLINK) {
++              || pktType === REQUEST.SYMLINK) {
+               /*
+                 RENAME:
+                   string     oldpath
+@@ -716,8 +718,8 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+     } else if (status === 'bad_pkt') {
+       if (server && buffer[4] !== REQUEST.INIT) {
+         var errCode = (buffer[4] === REQUEST.EXTENDED
+-                       ? STATUS_CODE.OP_UNSUPPORTED
+-                       : STATUS_CODE.FAILURE);
++          ? STATUS_CODE.OP_UNSUPPORTED
++          : STATUS_CODE.FAILURE);
+ 
+         // no request id for init/version packets, so we have no way to send a
+         // status response, so we just close up shop ...
+@@ -751,19 +753,19 @@ SFTPStream.prototype._transform = function(chunk, encoding, callback) {
+ };
+ 
+ // client
+-SFTPStream.prototype.createReadStream = function(path, options) {
++SFTPStream.prototype.createReadStream = function (path, options) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+   return new ReadStream(this, path, options);
+ };
+-SFTPStream.prototype.createWriteStream = function(path, options) {
++SFTPStream.prototype.createWriteStream = function (path, options) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+   return new WriteStream(this, path, options);
+ };
+-SFTPStream.prototype.open = function(path, flags_, attrs, cb) {
++SFTPStream.prototype.open = function (path, flags_, attrs, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -820,7 +822,7 @@ SFTPStream.prototype.open = function(path, flags_, attrs, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing OPEN');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.close = function(handle, cb) {
++SFTPStream.prototype.close = function (handle, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!Buffer.isBuffer(handle))
+@@ -849,7 +851,7 @@ SFTPStream.prototype.close = function(handle, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing CLOSE');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.readData = function(handle, buf, off, len, position, cb) {
++SFTPStream.prototype.readData = function (handle, buf, off, len, position, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!Buffer.isBuffer(handle))
+@@ -891,7 +893,7 @@ SFTPStream.prototype.readData = function(handle, buf, off, len, position, cb) {
+   out.writeUInt32BE(len, p += 8, true);
+ 
+   state.requests[reqid] = {
+-    cb: function(err, data, nb) {
++    cb: function (err, data, nb) {
+       if (err && err.code !== STATUS_CODE.EOF)
+         return cb(err);
+       cb(undefined, nb || 0, data, position);
+@@ -902,7 +904,7 @@ SFTPStream.prototype.readData = function(handle, buf, off, len, position, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing READ');
+   return this.push(out);
+ };
+-SFTPStream.prototype.writeData = function(handle, buf, off, len, position, cb) {
++SFTPStream.prototype.writeData = function (handle, buf, off, len, position, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!Buffer.isBuffer(handle))
+@@ -920,13 +922,13 @@ SFTPStream.prototype.writeData = function(handle, buf, off, len, position, cb) {
+   var state = this._state;
+ 
+   if (!len) {
+-    cb && process.nextTick(function() { cb(undefined, 0); });
++    cb && process.nextTick(function () { cb(undefined, 0); });
+     return;
+   }
+ 
+   var overflow = (len > state.maxDataLen
+-                  ? len - state.maxDataLen
+-                  : 0);
++    ? len - state.maxDataLen
++    : 0);
+   var origPosition = position;
+ 
+   if (overflow)
+@@ -958,16 +960,16 @@ SFTPStream.prototype.writeData = function(handle, buf, off, len, position, cb) {
+   buf.copy(out, p += 4, off, off + len);
+ 
+   state.requests[reqid] = {
+-    cb: function(err) {
++    cb: function (err) {
+       if (err)
+         cb && cb(err);
+       else if (overflow) {
+         self.writeData(handle,
+-                       buf,
+-                       off + len,
+-                       overflow,
+-                       origPosition + len,
+-                       cb);
++          buf,
++          off + len,
++          overflow,
++          origPosition + len,
++          cb);
+       } else
+         cb && cb(undefined, off + len);
+     }
+@@ -994,12 +996,12 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+     cb = opts;
+   } else if (typeof opts === 'object') {
+     if (typeof opts.concurrency === 'number'
+-        && opts.concurrency > 0
+-        && !isNaN(opts.concurrency))
++      && opts.concurrency > 0
++      && !isNaN(opts.concurrency))
+       concurrency = opts.concurrency;
+     if (typeof opts.chunkSize === 'number'
+-        && opts.chunkSize > 0
+-        && !isNaN(opts.chunkSize))
++      && opts.chunkSize > 0
++      && !isNaN(opts.chunkSize))
+       chunkSize = opts.chunkSize;
+     if (typeof opts.step === 'function')
+       onstep = opts.step;
+@@ -1031,7 +1033,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+     var cbfinal;
+ 
+     if (srcHandle || dstHandle) {
+-      cbfinal = function() {
++      cbfinal = function () {
+         if (--left === 0)
+           cb(err);
+       };
+@@ -1047,7 +1049,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+       cb(err);
+   }
+ 
+-  src.open(srcPath, 'r', function(err, sourceHandle) {
++  src.open(srcPath, 'r', function (err, sourceHandle) {
+     if (err)
+       return onerror(err);
+ 
+@@ -1058,7 +1060,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+         if (src !== fs) {
+           // Try stat() for sftp servers that may not support fstat() for
+           // whatever reason
+-          src.stat(srcPath, function(err_, attrs_) {
++          src.stat(srcPath, function (err_, attrs_) {
+             if (err_)
+               return onerror(err);
+             tryStat(null, attrs_);
+@@ -1069,7 +1071,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+       }
+       fsize = attrs.size;
+ 
+-      dst.open(dstPath, 'w', function(err, destHandle) {
++      dst.open(dstPath, 'w', function (err, destHandle) {
+         if (err)
+           return onerror(err);
+ 
+@@ -1097,7 +1099,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+             if (err) {
+               // Try chmod() for sftp servers that may not support fchmod() for
+               // whatever reason
+-              dst.chmod(dstPath, mode, function(err_) {
++              dst.chmod(dstPath, mode, function (err_) {
+                 tryAgain();
+               });
+               return;
+@@ -1126,11 +1128,11 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+ 
+             if (--reads === 0) {
+               if (total === fsize) {
+-                dst.close(dstHandle, function(err) {
++                dst.close(dstHandle, function (err) {
+                   dstHandle = undefined;
+                   if (err)
+                     return onerror(err);
+-                  src.close(srcHandle, function(err) {
++                  src.close(srcHandle, function (err) {
+                     srcHandle = undefined;
+                     if (err)
+                       return onerror(err);
+@@ -1144,7 +1146,7 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+         }
+ 
+         function makeCb(psrc, pdst) {
+-          return function(err, nb, data) {
++          return function (err, nb, data) {
+             onread(err, nb, data, pdst, psrc);
+           };
+         }
+@@ -1154,11 +1156,11 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+             chunk = (pdst + chunkSize > fsize ? fsize - pdst : chunkSize);
+             if (src === fs) {
+               src.read(srcHandle,
+-                       readbuf,
+-                       psrc,
+-                       chunk,
+-                       pdst,
+-                       makeCb(psrc, pdst));
++                readbuf,
++                psrc,
++                chunk,
++                pdst,
++                makeCb(psrc, pdst));
+             } else
+               src.readData(srcHandle, readbuf, psrc, chunk, pdst, onread);
+             psrc += chunk;
+@@ -1171,19 +1173,19 @@ function fastXfer(src, dst, srcPath, dstPath, opts, cb) {
+     });
+   });
+ }
+-SFTPStream.prototype.fastGet = function(remotePath, localPath, opts, cb) {
++SFTPStream.prototype.fastGet = function (remotePath, localPath, opts, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+   fastXfer(this, fs, remotePath, localPath, opts, cb);
+ };
+-SFTPStream.prototype.fastPut = function(localPath, remotePath, opts, cb) {
++SFTPStream.prototype.fastPut = function (localPath, remotePath, opts, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+   fastXfer(fs, this, localPath, remotePath, opts, cb);
+ };
+-SFTPStream.prototype.readFile = function(path, options, callback_) {
++SFTPStream.prototype.readFile = function (path, options, callback_) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1220,7 +1222,7 @@ SFTPStream.prototype.readFile = function(path, options, callback_) {
+   var bytesRead = 0;
+ 
+   var flag = options.flag || 'r';
+-  this.open(path, flag, 438 /*=0666*/, function(er, handle_) {
++  this.open(path, flag, 438 /*=0666*/, function (er, handle_) {
+     if (er)
+       return callback && callback(er);
+     handle = handle_;
+@@ -1229,9 +1231,9 @@ SFTPStream.prototype.readFile = function(path, options, callback_) {
+       if (er) {
+         // Try stat() for sftp servers that may not support fstat() for
+         // whatever reason
+-        self.stat(path, function(er_, st_) {
++        self.stat(path, function (er_, st_) {
+           if (er_) {
+-            return self.close(handle, function() {
++            return self.close(handle, function () {
+               callback && callback(er);
+             });
+           }
+@@ -1263,7 +1265,7 @@ SFTPStream.prototype.readFile = function(path, options, callback_) {
+ 
+   function afterRead(er, nbytes) {
+     if (er) {
+-      return self.close(handle, function() {
++      return self.close(handle, function () {
+         return callback && callback(er);
+       });
+     }
+@@ -1286,7 +1288,7 @@ SFTPStream.prototype.readFile = function(path, options, callback_) {
+   }
+ 
+   function close() {
+-    self.close(handle, function(er) {
++    self.close(handle, function (er) {
+       if (size === 0) {
+         // collected the data into the buffers list.
+         buffer = Buffer.concat(buffers, pos);
+@@ -1303,27 +1305,27 @@ function writeAll(self, handle, buffer, offset, length, position, callback_) {
+   var callback = (typeof callback_ === 'function' ? callback_ : undefined);
+ 
+   self.writeData(handle,
+-                 buffer,
+-                 offset,
+-                 length,
+-                 position,
+-                 function(writeErr, written) {
+-    if (writeErr) {
+-      return self.close(handle, function() {
+-        callback && callback(writeErr);
+-      });
+-    }
+-    if (written === length)
+-      self.close(handle, callback);
+-    else {
+-      offset += written;
+-      length -= written;
+-      position += written;
+-      writeAll(self, handle, buffer, offset, length, position, callback);
+-    }
+-  });
++    buffer,
++    offset,
++    length,
++    position,
++    function (writeErr, written) {
++      if (writeErr) {
++        return self.close(handle, function () {
++          callback && callback(writeErr);
++        });
++      }
++      if (written === length)
++        self.close(handle, callback);
++      else {
++        offset += written;
++        length -= written;
++        position += written;
++        writeAll(self, handle, buffer, offset, length, position, callback);
++      }
++    });
+ }
+-SFTPStream.prototype.writeFile = function(path, data, options, callback_) {
++SFTPStream.prototype.writeFile = function (path, data, options, callback_) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1347,13 +1349,13 @@ SFTPStream.prototype.writeFile = function(path, data, options, callback_) {
+     throw new Error('Unknown encoding: ' + options.encoding);
+ 
+   var flag = options.flag || 'w';
+-  this.open(path, flag, options.mode, function(openErr, handle) {
++  this.open(path, flag, options.mode, function (openErr, handle) {
+     if (openErr)
+       callback && callback(openErr);
+     else {
+       var buffer = (Buffer.isBuffer(data)
+-                    ? data
+-                    : new Buffer('' + data, options.encoding || 'utf8'));
++        ? data
++        : new Buffer('' + data, options.encoding || 'utf8'));
+       var position = (/a/.test(flag) ? null : 0);
+ 
+       // SFTPv3 does not support the notion of 'current position'
+@@ -1364,9 +1366,9 @@ SFTPStream.prototype.writeFile = function(path, data, options, callback_) {
+           if (er) {
+             // Try stat() for sftp servers that may not support fstat() for
+             // whatever reason
+-            self.stat(path, function(er_, st_) {
++            self.stat(path, function (er_, st_) {
+               if (er_) {
+-                return self.close(handle, function() {
++                return self.close(handle, function () {
+                   callback && callback(er);
+                 });
+               }
+@@ -1382,7 +1384,7 @@ SFTPStream.prototype.writeFile = function(path, data, options, callback_) {
+     }
+   });
+ };
+-SFTPStream.prototype.appendFile = function(path, data, options, callback_) {
++SFTPStream.prototype.appendFile = function (path, data, options, callback_) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1405,15 +1407,15 @@ SFTPStream.prototype.appendFile = function(path, data, options, callback_) {
+     options = util._extend({ flag: 'a' }, options);
+   this.writeFile(path, data, options, callback);
+ };
+-SFTPStream.prototype.exists = function(path, cb) {
++SFTPStream.prototype.exists = function (path, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+-  this.stat(path, function(err) {
++  this.stat(path, function (err) {
+     cb && cb(err ? false : true);
+   });
+ };
+-SFTPStream.prototype.unlink = function(filename, cb) {
++SFTPStream.prototype.unlink = function (filename, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1440,7 +1442,7 @@ SFTPStream.prototype.unlink = function(filename, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing REMOVE');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.rename = function(oldPath, newPath, cb) {
++SFTPStream.prototype.rename = function (oldPath, newPath, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1471,7 +1473,7 @@ SFTPStream.prototype.rename = function(oldPath, newPath, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing RENAME');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.mkdir = function(path, attrs, cb) {
++SFTPStream.prototype.mkdir = function (path, attrs, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1519,7 +1521,7 @@ SFTPStream.prototype.mkdir = function(path, attrs, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing MKDIR');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.rmdir = function(path, cb) {
++SFTPStream.prototype.rmdir = function (path, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1546,7 +1548,7 @@ SFTPStream.prototype.rmdir = function(path, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing RMDIR');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.readdir = function(where, opts, cb) {
++SFTPStream.prototype.readdir = function (where, opts, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1574,15 +1576,15 @@ SFTPStream.prototype.readdir = function(where, opts, cb) {
+       if (err)
+         return cb(err);
+ 
+-      self.readdir(handle, opts, function(err, list) {
++      self.readdir(handle, opts, function (err, list) {
+         var eof = (err && err.code === STATUS_CODE.EOF);
+ 
+         if (err && !eof) {
+-          return self.close(handle, function() {
++          return self.close(handle, function () {
+             cb(err);
+           });
+         } else if (eof) {
+-          return self.close(handle, function(err) {
++          return self.close(handle, function (err) {
+             if (err)
+               return cb(err);
+             cb(undefined, entries);
+@@ -1615,24 +1617,24 @@ SFTPStream.prototype.readdir = function(where, opts, cb) {
+ 
+   state.requests[reqid] = {
+     cb: (doFilter
+-         ? function(err, list) {
+-             if (err)
+-               return cb(err);
+-
+-             for (var i = list.length - 1; i >= 0; --i) {
+-               if (list[i].filename === '.' || list[i].filename === '..')
+-                 list.splice(i, 1);
+-             }
+-
+-             cb(undefined, list);
+-           }
+-         : cb)
++      ? function (err, list) {
++        if (err)
++          return cb(err);
++
++        for (var i = list.length - 1; i >= 0; --i) {
++          if (list[i].filename === '.' || list[i].filename === '..')
++            list.splice(i, 1);
++        }
++
++        cb(undefined, list);
++      }
++      : cb)
+   };
+ 
+   this.debug('DEBUG[SFTP]: Outgoing: Writing READDIR');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.fstat = function(handle, cb) {
++SFTPStream.prototype.fstat = function (handle, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!Buffer.isBuffer(handle))
+@@ -1661,7 +1663,7 @@ SFTPStream.prototype.fstat = function(handle, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing FSTAT');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.stat = function(path, cb) {
++SFTPStream.prototype.stat = function (path, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1688,7 +1690,7 @@ SFTPStream.prototype.stat = function(path, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing STAT');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.lstat = function(path, cb) {
++SFTPStream.prototype.lstat = function (path, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1715,7 +1717,7 @@ SFTPStream.prototype.lstat = function(path, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing LSTAT');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.opendir = function(path, cb) {
++SFTPStream.prototype.opendir = function (path, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1742,7 +1744,7 @@ SFTPStream.prototype.opendir = function(path, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing OPENDIR');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.setstat = function(path, attrs, cb) {
++SFTPStream.prototype.setstat = function (path, attrs, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1787,7 +1789,7 @@ SFTPStream.prototype.setstat = function(path, attrs, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing SETSTAT');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.fsetstat = function(handle, attrs, cb) {
++SFTPStream.prototype.fsetstat = function (handle, attrs, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!Buffer.isBuffer(handle))
+@@ -1834,41 +1836,41 @@ SFTPStream.prototype.fsetstat = function(handle, attrs, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing FSETSTAT');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.futimes = function(handle, atime, mtime, cb) {
++SFTPStream.prototype.futimes = function (handle, atime, mtime, cb) {
+   return this.fsetstat(handle, {
+     atime: toUnixTimestamp(atime),
+     mtime: toUnixTimestamp(mtime)
+   }, cb);
+ };
+-SFTPStream.prototype.utimes = function(path, atime, mtime, cb) {
++SFTPStream.prototype.utimes = function (path, atime, mtime, cb) {
+   return this.setstat(path, {
+     atime: toUnixTimestamp(atime),
+     mtime: toUnixTimestamp(mtime)
+   }, cb);
+ };
+-SFTPStream.prototype.fchown = function(handle, uid, gid, cb) {
++SFTPStream.prototype.fchown = function (handle, uid, gid, cb) {
+   return this.fsetstat(handle, {
+     uid: uid,
+     gid: gid
+   }, cb);
+ };
+-SFTPStream.prototype.chown = function(path, uid, gid, cb) {
++SFTPStream.prototype.chown = function (path, uid, gid, cb) {
+   return this.setstat(path, {
+     uid: uid,
+     gid: gid
+   }, cb);
+ };
+-SFTPStream.prototype.fchmod = function(handle, mode, cb) {
++SFTPStream.prototype.fchmod = function (handle, mode, cb) {
+   return this.fsetstat(handle, {
+     mode: mode
+   }, cb);
+ };
+-SFTPStream.prototype.chmod = function(path, mode, cb) {
++SFTPStream.prototype.chmod = function (path, mode, cb) {
+   return this.setstat(path, {
+     mode: mode
+   }, cb);
+ };
+-SFTPStream.prototype.readlink = function(path, cb) {
++SFTPStream.prototype.readlink = function (path, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1891,7 +1893,7 @@ SFTPStream.prototype.readlink = function(path, cb) {
+   buf.write(path, p += 4, pathlen, 'utf8');
+ 
+   state.requests[reqid] = {
+-    cb: function(err, names) {
++    cb: function (err, names) {
+       if (err)
+         return cb(err);
+       else if (!names || !names.length)
+@@ -1903,7 +1905,7 @@ SFTPStream.prototype.readlink = function(path, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing READLINK');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.symlink = function(targetPath, linkPath, cb) {
++SFTPStream.prototype.symlink = function (targetPath, linkPath, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1942,7 +1944,7 @@ SFTPStream.prototype.symlink = function(targetPath, linkPath, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing SYMLINK');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.realpath = function(path, cb) {
++SFTPStream.prototype.realpath = function (path, cb) {
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+ 
+@@ -1965,7 +1967,7 @@ SFTPStream.prototype.realpath = function(path, cb) {
+   buf.write(path, p += 4, pathlen, 'utf8');
+ 
+   state.requests[reqid] = {
+-    cb: function(err, names) {
++    cb: function (err, names) {
+       if (err)
+         return cb(err);
+       else if (!names || !names.length)
+@@ -1978,13 +1980,13 @@ SFTPStream.prototype.realpath = function(path, cb) {
+   return this.push(buf);
+ };
+ // extended requests
+-SFTPStream.prototype.ext_openssh_rename = function(oldPath, newPath, cb) {
++SFTPStream.prototype.ext_openssh_rename = function (oldPath, newPath, cb) {
+   var state = this._state;
+ 
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!state.extensions['posix-rename@openssh.com']
+-           || state.extensions['posix-rename@openssh.com'].indexOf('1') === -1)
++    || state.extensions['posix-rename@openssh.com'].indexOf('1') === -1)
+     throw new Error('Server does not support this extended request');
+ 
+   /*
+@@ -2015,13 +2017,13 @@ SFTPStream.prototype.ext_openssh_rename = function(oldPath, newPath, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing posix-rename@openssh.com');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.ext_openssh_statvfs = function(path, cb) {
++SFTPStream.prototype.ext_openssh_statvfs = function (path, cb) {
+   var state = this._state;
+ 
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!state.extensions['statvfs@openssh.com']
+-           || state.extensions['statvfs@openssh.com'].indexOf('2') === -1)
++    || state.extensions['statvfs@openssh.com'].indexOf('2') === -1)
+     throw new Error('Server does not support this extended request');
+ 
+   /*
+@@ -2051,13 +2053,13 @@ SFTPStream.prototype.ext_openssh_statvfs = function(path, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing statvfs@openssh.com');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.ext_openssh_fstatvfs = function(handle, cb) {
++SFTPStream.prototype.ext_openssh_fstatvfs = function (handle, cb) {
+   var state = this._state;
+ 
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!state.extensions['fstatvfs@openssh.com']
+-           || state.extensions['fstatvfs@openssh.com'].indexOf('2') === -1)
++    || state.extensions['fstatvfs@openssh.com'].indexOf('2') === -1)
+     throw new Error('Server does not support this extended request');
+   else if (!Buffer.isBuffer(handle))
+     throw new Error('handle is not a Buffer');
+@@ -2089,13 +2091,13 @@ SFTPStream.prototype.ext_openssh_fstatvfs = function(handle, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing fstatvfs@openssh.com');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.ext_openssh_hardlink = function(oldPath, newPath, cb) {
++SFTPStream.prototype.ext_openssh_hardlink = function (oldPath, newPath, cb) {
+   var state = this._state;
+ 
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!state.extensions['hardlink@openssh.com']
+-           || state.extensions['hardlink@openssh.com'].indexOf('1') === -1)
++    || state.extensions['hardlink@openssh.com'].indexOf('1') === -1)
+     throw new Error('Server does not support this extended request');
+ 
+   /*
+@@ -2126,13 +2128,13 @@ SFTPStream.prototype.ext_openssh_hardlink = function(oldPath, newPath, cb) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing hardlink@openssh.com');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.ext_openssh_fsync = function(handle, cb) {
++SFTPStream.prototype.ext_openssh_fsync = function (handle, cb) {
+   var state = this._state;
+ 
+   if (this.server)
+     throw new Error('Client-only method called in server mode');
+   else if (!state.extensions['fsync@openssh.com']
+-           || state.extensions['fsync@openssh.com'].indexOf('1') === -1)
++    || state.extensions['fsync@openssh.com'].indexOf('1') === -1)
+     throw new Error('Server does not support this extended request');
+   else if (!Buffer.isBuffer(handle))
+     throw new Error('handle is not a Buffer');
+@@ -2163,7 +2165,7 @@ SFTPStream.prototype.ext_openssh_fsync = function(handle, cb) {
+ };
+ 
+ // server
+-SFTPStream.prototype.status = function(id, code, message, lang) {
++SFTPStream.prototype.status = function (id, code, message, lang) {
+   if (!this.server)
+     throw new Error('Server-only method called in client mode');
+ 
+@@ -2194,7 +2196,7 @@ SFTPStream.prototype.status = function(id, code, message, lang) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing STATUS');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.handle = function(id, handle) {
++SFTPStream.prototype.handle = function (id, handle) {
+   if (!this.server)
+     throw new Error('Server-only method called in client mode');
+ 
+@@ -2219,7 +2221,7 @@ SFTPStream.prototype.handle = function(id, handle) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing HANDLE');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.data = function(id, data, encoding) {
++SFTPStream.prototype.data = function (id, data, encoding) {
+   if (!this.server)
+     throw new Error('Server-only method called in client mode');
+ 
+@@ -2249,12 +2251,12 @@ SFTPStream.prototype.data = function(id, data, encoding) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing DATA');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.name = function(id, names) {
++SFTPStream.prototype.name = function (id, names) {
+   if (!this.server)
+     throw new Error('Server-only method called in client mode');
+ 
+   if (!Array.isArray(names) && typeof names === 'object')
+-    names = [ names ];
++    names = [names];
+   else if (!Array.isArray(names))
+     throw new Error('names is not an object or array');
+ 
+@@ -2277,12 +2279,12 @@ SFTPStream.prototype.name = function(id, names) {
+   for (i = 0; i < count; ++i) {
+     name = names[i];
+     filename = (!name || !name.filename || typeof name.filename !== 'string'
+-                ? ''
+-                : name.filename);
++      ? ''
++      : name.filename);
+     namesLen += 4 + Buffer.byteLength(filename);
+     longname = (!name || !name.longname || typeof name.longname !== 'string'
+-                ? ''
+-                : name.longname);
++      ? ''
++      : name.longname);
+     namesLen += 4 + Buffer.byteLength(longname);
+ 
+     if (typeof name.attrs === 'object') {
+@@ -2309,8 +2311,8 @@ SFTPStream.prototype.name = function(id, names) {
+     name = names[i];
+ 
+     filename = (!name || !name.filename || typeof name.filename !== 'string'
+-                ? ''
+-                : name.filename);
++      ? ''
++      : name.filename);
+     len = Buffer.byteLength(filename);
+     buf.writeUInt32BE(len, p, true);
+     p += 4;
+@@ -2320,8 +2322,8 @@ SFTPStream.prototype.name = function(id, names) {
+     }
+ 
+     longname = (!name || !name.longname || typeof name.longname !== 'string'
+-                ? ''
+-                : name.longname);
++      ? ''
++      : name.longname);
+     len = Buffer.byteLength(longname);
+     buf.writeUInt32BE(len, p, true);
+     p += 4;
+@@ -2349,7 +2351,7 @@ SFTPStream.prototype.name = function(id, names) {
+   this.debug('DEBUG[SFTP]: Outgoing: Writing NAME');
+   return this.push(buf);
+ };
+-SFTPStream.prototype.attrs = function(id, attrs) {
++SFTPStream.prototype.attrs = function (id, attrs) {
+   if (!this.server)
+     throw new Error('Server-only method called in client mode');
+ 
+@@ -2499,33 +2501,33 @@ function attrsToBytes(attrs) {
+     flags |= ATTR.UIDGID;
+     attrBytes += 8;
+     ret.push([(attrs.uid >> 24) & 0xFF, (attrs.uid >> 16) & 0xFF,
+-              (attrs.uid >> 8) & 0xFF, attrs.uid & 0xFF]);
++    (attrs.uid >> 8) & 0xFF, attrs.uid & 0xFF]);
+     ret.push([(attrs.gid >> 24) & 0xFF, (attrs.gid >> 16) & 0xFF,
+-              (attrs.gid >> 8) & 0xFF, attrs.gid & 0xFF]);
++    (attrs.gid >> 8) & 0xFF, attrs.gid & 0xFF]);
+   }
+   if (typeof attrs.permissions === 'number'
+-      || typeof attrs.permissions === 'string'
+-      || typeof attrs.mode === 'number'
+-      || typeof attrs.mode === 'string') {
++    || typeof attrs.permissions === 'string'
++    || typeof attrs.mode === 'number'
++    || typeof attrs.mode === 'string') {
+     var mode = modeNum(attrs.mode || attrs.permissions);
+     flags |= ATTR.PERMISSIONS;
+     attrBytes += 4;
+     ret.push([(mode >> 24) & 0xFF,
+-              (mode >> 16) & 0xFF,
+-              (mode >> 8) & 0xFF,
+-              mode & 0xFF]);
++    (mode >> 16) & 0xFF,
++    (mode >> 8) & 0xFF,
++    mode & 0xFF]);
+   }
+   if ((typeof attrs.atime === 'number' || isDate(attrs.atime))
+-      && (typeof attrs.mtime === 'number' || isDate(attrs.mtime))) {
++    && (typeof attrs.mtime === 'number' || isDate(attrs.mtime))) {
+     var atime = toUnixTimestamp(attrs.atime);
+     var mtime = toUnixTimestamp(attrs.mtime);
+ 
+     flags |= ATTR.ACMODTIME;
+     attrBytes += 8;
+     ret.push([(atime >> 24) & 0xFF, (atime >> 16) & 0xFF,
+-              (atime >> 8) & 0xFF, atime & 0xFF]);
++    (atime >> 8) & 0xFF, atime & 0xFF]);
+     ret.push([(mtime >> 24) & 0xFF, (mtime >> 16) & 0xFF,
+-              (mtime >> 8) & 0xFF, mtime & 0xFF]);
++    (mtime >> 8) & 0xFF, mtime & 0xFF]);
+   }
+   // TODO: extended attributes
+ 
+@@ -2556,17 +2558,17 @@ var stringFlagMap = {
+   'xw': OPEN_MODE.TRUNC | OPEN_MODE.CREAT | OPEN_MODE.WRITE | OPEN_MODE.EXCL,
+   'w+': OPEN_MODE.TRUNC | OPEN_MODE.CREAT | OPEN_MODE.READ | OPEN_MODE.WRITE,
+   'wx+': OPEN_MODE.TRUNC | OPEN_MODE.CREAT | OPEN_MODE.READ | OPEN_MODE.WRITE
+-         | OPEN_MODE.EXCL,
++    | OPEN_MODE.EXCL,
+   'xw+': OPEN_MODE.TRUNC | OPEN_MODE.CREAT | OPEN_MODE.READ | OPEN_MODE.WRITE
+-         | OPEN_MODE.EXCL,
++    | OPEN_MODE.EXCL,
+   'a': OPEN_MODE.APPEND | OPEN_MODE.CREAT | OPEN_MODE.WRITE,
+   'ax': OPEN_MODE.APPEND | OPEN_MODE.CREAT | OPEN_MODE.WRITE | OPEN_MODE.EXCL,
+   'xa': OPEN_MODE.APPEND | OPEN_MODE.CREAT | OPEN_MODE.WRITE | OPEN_MODE.EXCL,
+   'a+': OPEN_MODE.APPEND | OPEN_MODE.CREAT | OPEN_MODE.READ | OPEN_MODE.WRITE,
+   'ax+': OPEN_MODE.APPEND | OPEN_MODE.CREAT | OPEN_MODE.READ | OPEN_MODE.WRITE
+-         | OPEN_MODE.EXCL,
++    | OPEN_MODE.EXCL,
+   'xa+': OPEN_MODE.APPEND | OPEN_MODE.CREAT | OPEN_MODE.READ | OPEN_MODE.WRITE
+-         | OPEN_MODE.EXCL
++    | OPEN_MODE.EXCL
+ };
+ var stringFlagMapKeys = Object.keys(stringFlagMap);
+ 
+@@ -2597,28 +2599,28 @@ function Stats(initial) {
+   this.atime = (initial && initial.atime);
+   this.mtime = (initial && initial.mtime);
+ }
+-Stats.prototype._checkModeProperty = function(property) {
++Stats.prototype._checkModeProperty = function (property) {
+   return ((this.mode & constants.S_IFMT) === property);
+ };
+-Stats.prototype.isDirectory = function() {
++Stats.prototype.isDirectory = function () {
+   return this._checkModeProperty(constants.S_IFDIR);
+ };
+-Stats.prototype.isFile = function() {
++Stats.prototype.isFile = function () {
+   return this._checkModeProperty(constants.S_IFREG);
+ };
+-Stats.prototype.isBlockDevice = function() {
++Stats.prototype.isBlockDevice = function () {
+   return this._checkModeProperty(constants.S_IFBLK);
+ };
+-Stats.prototype.isCharacterDevice = function() {
++Stats.prototype.isCharacterDevice = function () {
+   return this._checkModeProperty(constants.S_IFCHR);
+ };
+-Stats.prototype.isSymbolicLink = function() {
++Stats.prototype.isSymbolicLink = function () {
+   return this._checkModeProperty(constants.S_IFLNK);
+ };
+-Stats.prototype.isFIFO = function() {
++Stats.prototype.isFIFO = function () {
+   return this._checkModeProperty(constants.S_IFIFO);
+ };
+-Stats.prototype.isSocket = function() {
++Stats.prototype.isSocket = function () {
+   return this._checkModeProperty(constants.S_IFSOCK);
+ };
+ SFTPStream.Stats = Stats;
+@@ -2680,7 +2682,7 @@ function ReadStream(sftp, path, options) {
+     this.pos = this.start;
+   }
+ 
+-  this.on('end', function() {
++  this.on('end', function () {
+     if (self.autoClose) {
+       self.destroy();
+     }
+@@ -2691,9 +2693,9 @@ function ReadStream(sftp, path, options) {
+ }
+ inherits(ReadStream, ReadableStream);
+ 
+-ReadStream.prototype.open = function() {
++ReadStream.prototype.open = function () {
+   var self = this;
+-  this.sftp.open(this.path, this.flags, this.mode, function(er, handle) {
++  this.sftp.open(this.path, this.flags, this.mode, function (er, handle) {
+     if (er) {
+       self.emit('error', er);
+       this.destroyed = this.closed = true;
+@@ -2708,9 +2710,9 @@ ReadStream.prototype.open = function() {
+   });
+ };
+ 
+-ReadStream.prototype._read = function(n) {
++ReadStream.prototype._read = function (n) {
+   if (!Buffer.isBuffer(this.handle)) {
+-    return this.once('open', function() {
++    return this.once('open', function () {
+       this._read(n);
+     });
+   }
+@@ -2762,7 +2764,7 @@ ReadStream.prototype._read = function(n) {
+   }
+ };
+ 
+-ReadStream.prototype.destroy = function() {
++ReadStream.prototype.destroy = function () {
+   if (this.destroyed)
+     return;
+   this.destroyed = true;
+@@ -2771,7 +2773,7 @@ ReadStream.prototype.destroy = function() {
+ };
+ 
+ 
+-ReadStream.prototype.close = function(cb) {
++ReadStream.prototype.close = function (cb) {
+   var self = this;
+   if (cb)
+     this.once('close', cb);
+@@ -2786,7 +2788,7 @@ ReadStream.prototype.close = function(cb) {
+   close();
+ 
+   function close(handle) {
+-    self.sftp.close(handle || self.handle, function(er) {
++    self.sftp.close(handle || self.handle, function (er) {
+       if (er)
+         self.emit('error', er);
+       else
+@@ -2846,9 +2848,9 @@ function WriteStream(sftp, path, options) {
+ }
+ inherits(WriteStream, WritableStream);
+ 
+-WriteStream.prototype.open = function() {
++WriteStream.prototype.open = function () {
+   var self = this;
+-  this.sftp.open(this.path, this.flags, this.mode, function(er, handle) {
++  this.sftp.open(this.path, this.flags, this.mode, function (er, handle) {
+     if (er) {
+       self.emit('error', er);
+       if (self.autoClose) {
+@@ -2864,7 +2866,7 @@ WriteStream.prototype.open = function() {
+       if (err) {
+         // Try chmod() for sftp servers that may not support fchmod() for
+         // whatever reason
+-        self.sftp.chmod(self.path, self.mode, function(err_) {
++        self.sftp.chmod(self.path, self.mode, function (err_) {
+           tryAgain();
+         });
+         return;
+@@ -2876,7 +2878,7 @@ WriteStream.prototype.open = function() {
+           if (err) {
+             // Try stat() for sftp servers that may not support fstat() for
+             // whatever reason
+-            self.sftp.stat(self.path, function(err_, st_) {
++            self.sftp.stat(self.path, function (err_, st_) {
+               if (err_) {
+                 self.destroy();
+                 self.emit('error', err);
+@@ -2897,38 +2899,38 @@ WriteStream.prototype.open = function() {
+   });
+ };
+ 
+-WriteStream.prototype._write = function(data, encoding, cb) {
++WriteStream.prototype._write = function (data, encoding, cb) {
+   if (!Buffer.isBuffer(data))
+     return this.emit('error', new Error('Invalid data'));
+ 
+   if (!Buffer.isBuffer(this.handle)) {
+-    return this.once('open', function() {
++    return this.once('open', function () {
+       this._write(data, encoding, cb);
+     });
+   }
+ 
+   var self = this;
+   this.sftp.writeData(this.handle,
+-                      data,
+-                      0,
+-                      data.length,
+-                      this.pos,
+-                      function(er, bytes) {
+-    if (er) {
+-      if (self.autoClose)
+-        self.destroy();
+-      return cb(er);
+-    }
+-    self.bytesWritten += bytes;
+-    cb();
+-  });
++    data,
++    0,
++    data.length,
++    this.pos,
++    function (er, bytes) {
++      if (er) {
++        if (self.autoClose)
++          self.destroy();
++        return cb(er);
++      }
++      self.bytesWritten += bytes;
++      cb();
++    });
+ 
+   this.pos += data.length;
+ };
+ 
+-WriteStream.prototype._writev = function(data, cb) {
++WriteStream.prototype._writev = function (data, cb) {
+   if (!Buffer.isBuffer(this.handle)) {
+-    return this.once('open', function() {
++    return this.once('open', function () {
+       this._writev(data, cb);
+     });
+   }

--- a/src/dnssd/avahi.ts
+++ b/src/dnssd/avahi.ts
@@ -61,7 +61,7 @@ async function getServer(): Promise<ServerObject> {
         // dbus-next will queue messages and wait forever for a connection
         // so we have to hack in a timeout, otherwise we end up with a deadlock
         // on systems without D-Bus.
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             const timeout = setTimeout(() => {
                 reject(Error("Timeout while connecting to D-Bus"));
             }, 100);
@@ -91,7 +91,7 @@ class AvahiClient implements dnssd.Client {
     }
 
     public createBrowser(options: dnssd.BrowseOptions): Promise<dnssd.Browser> {
-        return new Promise((resolve, reject) => {
+        return new Promise<dnssd.Browser>((resolve, reject) => {
             const browser = new AvahiBrowser(this, options);
             browser.once('ready', () => {
                 browser.removeAllListeners('error');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -717,7 +717,7 @@ class DeviceTreeItem extends vscode.TreeItem {
             location: vscode.ProgressLocation.Window,
             title: "Capturing screenshot..."
         }, progress => {
-            return new Promise(async (resolve, reject) => {
+            return new Promise<void>(async (resolve, reject) => {
                 const handleCaptureError = (e: any) => {
                     vscode.window.showErrorMessage("Error capturing screenshot: " + (e.message || e));
                     reject();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
 	"compilerOptions": {
 		"baseUrl": ".",
+		"useUnknownInCatchVariables": false,
+		"strictNullChecks": false,
+		"ignoreDeprecations": "6.0",
 		"paths": {
 			"*": [
 				"types/*"


### PR DESCRIPTION
This PR fixes upload failures when using ev3dev-browser with recent VS Code releases as described [here ](https://github.com/ev3dev/vscode-ev3dev-browser/issues/126)

Symptoms:
- TypeError: rc is not a function
- TypeError: isDate is not a function

Root cause:
- The extension's SFTP upload path relies on deprecated Node APIs that are no longer available in current VS Code runtimes.

Changes:
- Updated compatibility code to work with modern Node runtimes.
- Applied the minimal TypeScript fixes required to compile successfully.
- Verified that "Download and Run" works again with LEGO EV3 MicroPython.

Tested on:
- macOS
- Current VS Code release
- EV3 MicroPython project